### PR TITLE
Fix NPE for https://issues.jenkins-ci.org/browse/JENKINS-16042

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
@@ -66,7 +66,8 @@ public class MultiJobBuild extends Build<MultiJobProject, MultiJobBuild> {
 		private boolean evaluateResult(Result result) {
 			List<SubBuild> builders = getBuilders();
 			for (SubBuild subBuild : builders) {
-				if (subBuild.getResult().isWorseThan(result)) {
+				Result buildResult = subBuild.getResult();
+				if (buildResult != null && buildResult.isWorseThan(result)) {
 					return true;
 				}
 			}


### PR DESCRIPTION
Just added a test on the subBuild.getResult() to avoid NullPointerException
And so stop to have failures when the build is ok.

Ok, the real problem seems to be that when a build is success, result is null ...
Perhaps need to add more tests in the getBuilders method when sets the result ?
