### PR TITLE
Fixed the problem with the link to the sub-job console

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -125,7 +125,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
 										+ " with status :"
 										+ HyperlinkNote.encodeTo(
 												'/' + jobBuild.getUrl()
-														+ "/console/",
+														+ "/console",
 												result.toString()));
 						if (!continuationCondition.isContinue(jobBuild)) {
 							failed = true;


### PR DESCRIPTION
The extra slash character made the link invalid. Now the link points to the right sub-job console.
