### PR TITLE
[FIXED JENKINS-17576] [FIXED JENKINS-16870] support conditional buildstep plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,12 @@
 			<artifactId>envinject</artifactId>
 			<version>1.83</version>
 		</dependency>
+
+		<dependency>
+		    <groupId>org.jenkins-ci.plugins</groupId>
+		    <artifactId>conditional-buildstep</artifactId>
+		    <version>1.3.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/views/PhaseWrapper.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/views/PhaseWrapper.java
@@ -5,7 +5,6 @@ import hudson.model.Item;
 import hudson.model.ItemGroup;
 import hudson.model.Result;
 import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Hudson;
 import hudson.model.Job;
 
@@ -20,10 +19,13 @@ public class PhaseWrapper extends AbstractWrapper {
 	final int nestLevel;
 
 	final String phaseName;
+	
+	final boolean isConditional;
 
-	public PhaseWrapper(int nestLevel, String phaseName) {
+	public PhaseWrapper(int nestLevel, String phaseName, boolean isConditional) {
 		this.nestLevel = nestLevel;
 		this.phaseName = phaseName;
+		this.isConditional = isConditional;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -51,6 +53,10 @@ public class PhaseWrapper extends AbstractWrapper {
 		return nestLevel;
 	}
 
+	public boolean isConditional() {
+        return isConditional;
+    }
+	
 	// public AbstractProject getProject() {
 	// return project;
 	// }

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/views/JobColumn/column.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/views/JobColumn/column.jelly
@@ -4,10 +4,10 @@
 	<td style="${job.getCss()}">
 		<j:choose>
 			<j:when test="${job.phase}">
-				${job.displayName}
+				${job.isConditional() ? "[?]" : ""} ${job.displayName}
 			</j:when>
 			<j:when test="${!job.phase}">
-				<a href="${jobBaseUrl}${job.shortUrl}"> ${job.displayName}</a>
+				<a href="${jobBaseUrl}${job.shortUrl}">${job.displayName}</a>
 			</j:when>
 		</j:choose>
 	</td>

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
@@ -1,0 +1,98 @@
+package com.tikal.jenkins.plugins.multijob.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import hudson.model.Result;
+import hudson.model.TopLevelItem;
+import hudson.model.Cause.UserCause;
+import hudson.model.FreeStyleProject;
+import hudson.tasks.BuildStep;
+import hudson.tasks.Shell;
+
+import org.jenkins_ci.plugins.run_condition.BuildStepRunner;
+import org.jenkins_ci.plugins.run_condition.core.AlwaysRun;
+import org.jenkinsci.plugins.conditionalbuildstep.ConditionalBuilder;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import com.tikal.jenkins.plugins.multijob.MultiJobBuilder;
+import com.tikal.jenkins.plugins.multijob.MultiJobBuilder.ContinuationCondition;
+import com.tikal.jenkins.plugins.multijob.views.PhaseWrapper;
+import com.tikal.jenkins.plugins.multijob.views.ProjectWrapper;
+import com.tikal.jenkins.plugins.multijob.MultiJobProject;
+import com.tikal.jenkins.plugins.multijob.PhaseJobsConfig;
+
+/**
+ * @author Bartholdi Dominik (imod)
+ */
+public class ConditionalPhaseTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testConditionalPhase() throws Exception {
+        j.jenkins.getInjector().injectMembers(this);
+        
+        // MultiTop
+        //  |_ FirstPhase
+        //      |_ free
+        //  |_ [?] SecondPhase 
+        //          |_ free2
+
+        final FreeStyleProject free = j.jenkins.createProject(FreeStyleProject.class, "Free");
+        free.getBuildersList().add(new Shell("echo hello"));
+        final FreeStyleProject free2 = j.jenkins.createProject(FreeStyleProject.class, "Free2");
+        free2.getBuildersList().add(new Shell("echo hello2"));
+        
+        final MultiJobProject multi = j.jenkins.createProject(MultiJobProject.class, "MultiTop");
+
+        // create 'FirstPhase' containing job 'free'
+        PhaseJobsConfig firstPhase = new PhaseJobsConfig("free", null, true, null);
+        List<PhaseJobsConfig> configTopList = new ArrayList<PhaseJobsConfig>();
+        configTopList.add(firstPhase);
+        MultiJobBuilder firstPhaseBuilder = new MultiJobBuilder("FirstPhase", configTopList, ContinuationCondition.SUCCESSFUL);
+        
+        
+        // create 'SecondPhase' containing job 'free2'
+        PhaseJobsConfig secondPhase = new PhaseJobsConfig("free2", null, true, null);
+        List<PhaseJobsConfig> configTopList2 = new ArrayList<PhaseJobsConfig>();
+        configTopList.add(secondPhase);
+        MultiJobBuilder secondPhaseBuilder = new MultiJobBuilder("SecondPhase", configTopList2, ContinuationCondition.SUCCESSFUL);
+        
+        multi.getBuildersList().add(new Shell("echo dude"));
+        multi.getBuildersList().add(firstPhaseBuilder);
+
+        // wrap second phase in condition
+        List<BuildStep> blist = new ArrayList<BuildStep>();
+        blist.add(secondPhaseBuilder);
+        multi.getBuildersList().add(new ConditionalBuilder(new AlwaysRun(), new BuildStepRunner.Run(), blist));
+
+        j.assertBuildStatus(Result.SUCCESS, multi.scheduleBuild2(0, new UserCause()).get());
+        Assert.assertTrue("shell task writes 'hello' to log", free.getLastBuild().getLog(10).contains("hello"));
+        Assert.assertTrue("shell task writes 'dude' to log", multi.getLastBuild().getLog(10).contains("dude"));
+        
+        // check for correct number of items to be displayed
+        int numberOfPhases = 0;
+        int numberOfConditionalPhases = 0;
+        int numberOfProjects = 0;
+        for (TopLevelItem item : multi.getView().getRootItem(multi)) {
+            if(item instanceof ProjectWrapper) {
+                ++numberOfProjects;
+            }else if (item instanceof PhaseWrapper) {
+                ++numberOfPhases;
+                if(((PhaseWrapper)item).isConditional()) {
+                    ++numberOfConditionalPhases;
+                }
+            }
+        }
+        Assert.assertEquals("there should be two phases and three projects", 5, multi.getView().getRootItem(multi).size());
+        Assert.assertEquals("there should be two phases", 2, numberOfPhases);
+        Assert.assertEquals("there should be three projects", 3, numberOfProjects);
+        Assert.assertEquals("there should be 1 conditional phase", 1, numberOfConditionalPhases);
+        
+    }
+
+}


### PR DESCRIPTION
This PR fixes two issues: 

https://issues.jenkins-ci.org/browse/JENKINS-16870
https://issues.jenkins-ci.org/browse/JENKINS-17576

Phases can now be wrapped within a condition and therefore very flexible configurations are supported.
e.g. a phase can be skipped by buildparameters or if a file exists - basically every condition supported by the conditional buildstep can be used.
