### PR TITLE
Put back code so that MultiJob works when sub-jobs are disabled

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -85,6 +85,14 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
 		List<AbstractProject> projectList = new ArrayList<AbstractProject>();
 		for (PhaseSubJob phaseSubJob : phaseSubJobs.keySet()) {
 			AbstractProject subJob = phaseSubJob.job;
+                       
+                        if (subJob.isDisabled()) {
+                            listener.getLogger().println(String
+                                    .format("Skipping %s. This Job has been disabled.",
+                                    subJob.getName()));
+                            continue;
+                        }
+                        
 			reportStart(listener, subJob);
 			PhaseJobsConfig projectConfig = phaseSubJobs.get(phaseSubJob);
 			List<Action> actions = new ArrayList<Action>();
@@ -100,8 +108,8 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
 					actions.toArray(new Action[0]));
 
 			if (future == null) {
-				listener.getLogger().printf(
-                                        String.format("Warning: can't execute %s build.\n",
+				listener.getLogger().println(
+                                        String.format("Warning: can't execute %s build.",
                                         subJob.getName()));
 			} else {
                             futuresList.add(future);


### PR DESCRIPTION
After below if-case was removed (02-Aug 2013) a MultiJob gets java.lang.NullPointerException when a sub-job is disabled.

if (future != null) {
    futuresList.add(future);
    projectList.add(project);
}

I put this check back and now it works for me.
