### PR TITLE
Fixed so that warning message about multiple upstream jobs is not shown ...

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
@@ -162,7 +162,7 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 			for (Project project : projects) {
 				if (value.equalsIgnoreCase(project.getName())) {
 					List upstreamProjects = project.getUpstreamProjects();
-					if (upstreamProjects != null && upstreamProjects.size() > 0)
+					if (upstreamProjects != null && upstreamProjects.size() > 1)
 						return true;
 					return false;
 				}


### PR DESCRIPTION
...when there is only one upstream job.

This error message is shown even though there is only one upstream job.
 "There are other upstream projects for this job. It's possible, although very low probability, that multijob will be unable to execute concurrently the same job, due to Jenkins limitation. In such cases, recommended to clone the job."

This fixes that

Also see https://issues.jenkins-ci.org/browse/JENKINS-20790
