### PR TITLE
Fix access URL for sub job in MultiJobBuild view

### DIFF
--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuild/main.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuild/main.jelly
@@ -59,7 +59,7 @@
 	           			<span class="job"><img src="${imagesURL}/16x16/${builder.icon}" alt=""/></span>
 	 				</td>
 	 				<td class="no-wrap" width="50%">
-	 					<a href="/job/${builder.jobName}">${builder.jobName}</a>
+	 					<a href="${rootURL}/job/${builder.jobName}">${builder.jobName}</a>
 	 				</td>
 					<td class="no-wrap" width="15%">
 						<j:choose>


### PR DESCRIPTION
When hudson is not at the top path of the webserver (ie htt://server/hudson/), the link to the sub job was broken.
Use ${rootURL} to fix this

Signed-off-by: Nicolas Morey-Chaisemartin nmorey@kalray.eu
