### PR TITLE
Set jobBaseUrl in MultiJobView so that links to jobs will be under this view

### DIFF
--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/views/MultiJobView/configure-entries.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/views/MultiJobView/configure-entries.jelly
@@ -2,6 +2,6 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
 	xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
 	xmlns:i="jelly:fmt">
-
-
+      <!-- set @jobBaseUrl="" so that links to jobs will be under this view. -->
+      <t:buildListTable builds="${it.builds}" jobBaseUrl="" />	
 </j:jelly>


### PR DESCRIPTION
This patch makes the MultiJob view behaves as the other view.
It means that accessing a job through this view will generate a path
/view/#{viewName}/job/#{jobName} 

So the view shows up in the top menu and can be easily switched back to
