### PR TITLE
MultiJobBuilder.java: Sleep in the subtask polling loop

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -207,6 +207,12 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
 					}
 					if (future.isDone())
 						break;
+					try {
+						Thread.sleep(1000);
+					} catch (InterruptedException e) {
+						future.cancel(true);
+						throw new InterruptedException();
+					}
 				}
 				if (jobBuild != null) {
 					result = jobBuild.getResult();


### PR DESCRIPTION
Without the sleep, the thread keeps polling and updating the subtask which causes a very high CPU usage.
This fixes [JENKINS-21649] and [JENKINS-21798]

Signed-off-by: Nicolas Morey-Chaisemartin nmorey@kalray.eu
