### PR TITLE
[JENKINS-25111] Copy Artifacts from Phase Job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,20 @@
 			<artifactId>maven-plugin</artifactId>
 			<version>2.6</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>copyartifact</artifactId>
+			<version>1.31</version>
+			<optional>true</optional>
+    </dependency>
+		<dependency>
+			<groupId>org.jenkins-ci.plugins</groupId>
+			<artifactId>matrix-project</artifactId>
+			<version>1.4</version>
+			<optional>true</optional>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuildSelector.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuildSelector.java
@@ -1,0 +1,77 @@
+package com.tikal.jenkins.plugins.multijob;
+
+import java.util.logging.Logger;
+
+import hudson.matrix.MatrixRun;
+import hudson.plugins.copyartifact.BuildFilter;
+import hudson.plugins.copyartifact.BuildSelector;
+import hudson.plugins.copyartifact.Messages;
+import hudson.plugins.copyartifact.SimpleBuildSelectorDescriptor;
+import jenkins.model.Jenkins;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.Cause;
+import hudson.model.Cause.UpstreamCause;
+import hudson.model.Descriptor;
+import hudson.model.Job;
+import hudson.model.Run;
+
+/**
+ * Copy artifacts from the build that was part of this MultiJob build.
+ * @author Ray Sennewald
+ */
+public class MultiJobBuildSelector extends BuildSelector {
+    private static final Logger LOGGER = Logger.getLogger(MultiJobBuildSelector.class.getName());
+
+    @DataBoundConstructor
+    public MultiJobBuildSelector() { }
+
+    @Override
+    public Run<?, ?> getBuild(Job<?, ?> job, EnvVars env, BuildFilter filter, Run<?, ?> parent) {
+        MultiJobBuild multiJobBuild = null;
+        // Are we in the MultiJob itself and trying to get an artifact from a Phase Build?
+        if (parent instanceof MultiJobBuild) {
+            multiJobBuild = (MultiJobBuild)parent;
+        }
+        // Nope, look for Upstream MultiJob that triggered this run (Are we in a Phase job?)
+        else {
+			// Matrix run is triggered by its parent project, so check causes of parent build:
+			for (Cause cause : parent instanceof MatrixRun
+					? ((MatrixRun)parent).getParentBuild().getCauses() : parent.getCauses()) {
+                UpstreamCause upstreamCause = (UpstreamCause)cause;
+                Job upstreamJob = Jenkins.getInstance().getItemByFullName(upstreamCause.getUpstreamProject(), Job.class);
+                Run upstreamRun = upstreamJob.getBuildByNumber(upstreamCause.getUpstreamBuild());
+
+                if (upstreamRun != null && upstreamRun instanceof MultiJobBuild) {
+                    multiJobBuild = (MultiJobBuild)upstreamRun;
+                }
+            }
+        }
+        if (multiJobBuild == null) {
+            LOGGER.warning(String.format("'%s' is not found to be part of a MultiJob Project.", parent.getFullDisplayName()));
+            return null;
+        }
+        // Get the run for our source Job in the current MultiJob Project's Build
+        for (MultiJobBuild.SubBuild subBuild : multiJobBuild.getSubBuilds()) {
+            // Find Job's specific build we want
+            if (subBuild.getJobName().equals(job.getFullDisplayName())) {
+                return job.getBuildByNumber(subBuild.getBuildNumber());
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isSelectable(Run<?,?> run, EnvVars env) {
+        return true;
+    }
+
+    @Extension(ordinal=20)
+    public static final Descriptor<BuildSelector> DESCRIPTOR =
+            new SimpleBuildSelectorDescriptor(
+                    MultiJobBuildSelector.class,
+                    com.tikal.jenkins.plugins.multijob.Messages._MultiJobBuildSelector_DisplayName());
+}

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/Messages.properties
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/Messages.properties
@@ -1,0 +1,1 @@
+MultiJobBuildSelector.DisplayName=Build triggered by current MultiJob build

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuildSelector/config.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuildSelector/config.jelly
@@ -1,0 +1,27 @@
+<!--
+The MIT License
+
+Copyright (c) 2014, Ray Sennewald
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+    <f:entry title="${%Usage Note}" help="/plugin/jenkins-multijob-plugin/help-copyArtifact.html" />
+</j:jelly>

--- a/src/main/webapp/help-copyArtifact.html
+++ b/src/main/webapp/help-copyArtifact.html
@@ -1,0 +1,5 @@
+<div>
+    Note that copying from a build that was triggered by the current MultiJob
+    build only works if the destination is a MultiJob or a Phase Job of a
+    MultiJob and the source is a Phase Job of the same MultiJob.
+</div>

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/testutils/FileWriteBuilder.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/testutils/FileWriteBuilder.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License
+ * 
+ * Copyright (c) 2014 IKEDA Yasuyuki
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.tikal.jenkins.plugins.multijob.test.testutils;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Builder;
+
+/**
+ * Builder to write a file.
+ */
+public class FileWriteBuilder extends Builder {
+    private final String filename;
+    private final String content;
+    private final String encoding;
+
+    /**
+     * @param filename variables will be expanded
+     * @param content variables will be expanded
+     * @param encoding
+     */
+    public FileWriteBuilder(String filename, String content, String encoding) {
+        this.filename = filename;
+        this.content = content;
+        this.encoding = encoding;
+    }
+
+    /**
+     * @param filename variables will be expanded
+     * @param content variables will be expanded
+     */
+    public FileWriteBuilder(String filename, String content) {
+        this(filename, content, Charset.defaultCharset().name());
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher,
+                           BuildListener listener) throws InterruptedException, IOException {
+        EnvVars envVars = build.getEnvironment(listener);
+        String expandedFilename = envVars.expand(filename);
+        String expandedContent = envVars.expand(content);
+
+        FilePath file = build.getWorkspace().child(expandedFilename);
+        file.write(expandedContent, encoding);
+        return true;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        @Override
+        public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends AbstractProject> arg0) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "File Write Builder";
+        }
+    }
+}


### PR DESCRIPTION
THIS IS AN INTEGRATION WITH Copy Artifact Plugin.
-Added a new Build Selector called MultiJobBuildSelector
to CopyArtifact Build Selector.
-If selected, this will make the Copy Artifact Plugin look
for an artifact from that job's build which was part of the
current MultiJobBuild.
-This selector will work properly if you configure it with
a MultiJobProject which has a PhaseJob that archives an
artifact that you want to retrieve as part of the MultiJob.
-This selector will also work if you configure it to Copy an
Artifact from another Phase Job which was part of the
current MultiJob Build.
-Added tests to ensure this functionality works as expected.
-Adds CopyArtifact Plugin as an optional dependency.
-Updated Jenkins dependency to use v1.509.