### PR TITLE
switch the MultiJob plugin to use the config-customWorkspace jelly tag

### DIFF
--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobProject/configure-advanced.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobProject/configure-advanced.jelly
@@ -1,8 +1,3 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:p="/lib/hudson/project">
-  <f:optionalBlock name="customWorkspace" title="${%Use custom workspace}" checked="${it.customWorkspace!=null}"
-      help="/help/project-config/custom-workspace.html">
-    <f:entry title="${%Directory}">
-      <f:textbox name="customWorkspace.directory" value="${it.customWorkspace}" />
-    </f:entry>
-  </f:optionalBlock>
+  <p:config-customWorkspace />
  </j:jelly>


### PR DESCRIPTION
... in place of a stale inlined snapshot.

See the following JIRA bug: https://issues.jenkins-ci.org/browse/JENKINS-25221
