### PR TITLE
Add a shell command run condition for each job

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
@@ -51,6 +51,7 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 	private boolean currParams;
 	private boolean exposedSCM;
 	private boolean disableJob;
+	private String runCondition;
 	private List<AbstractBuildParameters> configs;
 	private KillPhaseOnJobResultCondition killPhaseOnJobResultCondition = KillPhaseOnJobResultCondition.NEVER;
 
@@ -87,6 +88,18 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 		this.currParams = currParams;
 	}
 
+	public boolean hasRunCondition() {
+		return !(runCondition == null || runCondition == "");
+	}
+
+	public String getRunCondition() {
+		return runCondition;
+	}
+
+	public void setRunCondition(String runCondition) {
+		this.runCondition = runCondition;
+	}
+
 	public String getJobProperties() {
 		return jobProperties;
 	}
@@ -115,13 +128,22 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 	public PhaseJobsConfig(String jobName, String jobProperties,
 			boolean currParams, List<AbstractBuildParameters> configs,
 			KillPhaseOnJobResultCondition killPhaseOnJobResultCondition,
-			boolean disableJob) {
+			boolean disableJob, String runCondition) {
 		this.jobName = jobName;
 		this.jobProperties = jobProperties;
 		this.currParams = currParams;
 		this.killPhaseOnJobResultCondition = killPhaseOnJobResultCondition;
 		this.disableJob = disableJob;
+		this.runCondition = runCondition;
 		this.configs = Util.fixNull(configs);
+	}
+
+	@Deprecated
+	public PhaseJobsConfig(String jobName, String jobProperties,
+			boolean currParams, List<AbstractBuildParameters> configs,
+			KillPhaseOnJobResultCondition killPhaseOnJobResultCondition,
+			boolean disableJob) {
+		this(jobName, jobProperties, currParams, configs, killPhaseOnJobResultCondition, disableJob, null);
 	}
 
 	public List<AbstractBuildParameters> getConfigs() {

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/ShellCondition.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/ShellCondition.java
@@ -1,0 +1,172 @@
+/*
+ * The MIT License
+ *
+ * Copyright (C) 2012 by Chris Johnson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.tikal.jenkins.plugins.multijob;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.model.Hudson;
+import hudson.tasks.Shell;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Executes a series of commands by using a shell.
+ *
+ * @author Chris Johnson (modifed by Brandon Turner)
+ */
+public class ShellCondition {
+
+    /**
+     * Command to execute.
+     */
+    protected final String command;
+
+    public ShellCondition(String command) {
+        this.command = fixCrLf(command);
+    }
+
+    public final String getCommand() {
+        return command;
+    }
+
+    public boolean runPerform(AbstractBuild<?, ?> build, BuildListener listener) throws InterruptedException {
+        FilePath ws = build.getWorkspace();
+        FilePath script = null;
+
+        try {
+            Launcher launcher = null;
+
+            try {
+                launcher = ws.createLauncher(listener);
+            }
+            catch (IOException e) {
+                Util.displayIOException(e,listener);
+                e.printStackTrace(listener.fatalError("Unable to create Launcher in " + ws));
+                return false;
+            }
+
+            try {
+                script = createScriptFile(ws);
+            } catch (IOException e) {
+                Util.displayIOException(e,listener);
+                e.printStackTrace(listener.fatalError("Unable to produce a script file"));
+                return false;
+            }
+
+            int r;
+            try {
+                EnvVars envVars = build.getEnvironment(listener);
+                // on Windows environment variables are converted to all upper case,
+                // but no such conversions are done on Unix, so to make this cross-platform,
+                // convert variables to all upper cases.
+                for(Map.Entry<String,String> e : build.getBuildVariables().entrySet())
+                    envVars.put(e.getKey(),e.getValue());
+
+                r = launcher.launch().cmds(buildCommandLine(script)).envs(envVars).stdout(listener).pwd(ws).join();
+
+            } catch (IOException e) {
+                Util.displayIOException(e,listener);
+                e.printStackTrace(listener.fatalError("command execution failed"));
+                r = -1;
+            }
+            return r==0;
+        } finally {
+            try {
+                if(script!=null)
+                script.delete();
+            } catch (IOException e) {
+                Util.displayIOException(e,listener);
+                e.printStackTrace( listener.fatalError("Unable to delete script file " + script) );
+            }
+        }
+    }
+
+
+    /**
+     * Creates a script file in a temporary name in the specified directory.
+     */
+    public FilePath createScriptFile(FilePath dir) throws IOException, InterruptedException {
+        return dir.createTextTempFile("ShellCondition", getFileExtension(), getContents(), false);
+    }
+
+    /**
+     * Fix CR/LF and always make it Unix style.
+     */
+    private static String fixCrLf(String s) {
+        // eliminate CR
+        int idx;
+        while((idx=s.indexOf("\r\n"))!=-1)
+            s = s.substring(0,idx)+s.substring(idx+1);
+        return s;
+    }
+
+    /**
+     * Older versions of bash have a bug where non-ASCII on the first line
+     * makes the shell think the file is a binary file and not a script. Adding
+     * a leading line feed works around this problem.
+     */
+    private static String addCrForNonASCII(String s) {
+        if(!s.startsWith("#!")) {
+            if (s.indexOf('\n')!=0) {
+                return "\n" + s;
+            }
+        }
+
+        return s;
+    }
+
+    public String[] buildCommandLine(FilePath script) {
+        if(command.startsWith("#!")) {
+            // interpreter override
+            int end = command.indexOf('\n');
+            if(end<0)   end=command.length();
+            List<String> args = new ArrayList<String>();
+            args.addAll(Arrays.asList(Util.tokenize(command.substring(0,end).trim())));
+            args.add(script.getRemote());
+            args.set(0,args.get(0).substring(2));   // trim off "#!"
+            return args.toArray(new String[args.size()]);
+        } else {
+            hudson.tasks.Shell.DescriptorImpl shellDesc = Hudson.getInstance().getDescriptorByType(Shell.DescriptorImpl.class);
+
+            return new String[] { shellDesc.getShellOrDefault(script.getChannel()), "-xe", script.getRemote()};
+        }
+    }
+
+    protected String getContents() {
+        return addCrForNonASCII(fixCrLf(command));
+    }
+
+    protected String getFileExtension() {
+        return ".sh";
+    }
+}

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
@@ -15,7 +15,13 @@
 				<f:advanced>
 				  	<f:entry title="Disable" field="disableJob">
   						<f:checkbox name="disableJob" checked="${instance.disableJob}" default="false"/>
-  					</f:entry>
+				  	</f:entry>
+				  	<f:entry field="runCondition"
+								title="Run condition command"
+								help="/plugin/jenkins-multijob-plugin/help-runCondition.html"
+								description="${%runConditionDescription(rootURL)}">
+							<f:textarea class="fixed-width" />
+				  	</f:entry>
 				    <f:entry title="Kill the phase on:" field="killPhaseOnJobResultCondition">
   						<f:enum field="killPhaseOnJobResultCondition">
 							${it.getLabel()}

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.properties
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.properties
@@ -1,0 +1,1 @@
+runConditionDescription=See <a href="{0}/env-vars.html" target=_new>the list of available environment variables</a>

--- a/src/main/webapp/help-runCondition.html
+++ b/src/main/webapp/help-runCondition.html
@@ -1,0 +1,20 @@
+<div>
+    A shell script that determines if this job should run.  A non-zero exit value will prevent
+    the job from running.
+
+    <p>
+    Type in the contents of your shell script. If your shell script has no header line like #!/bin/sh,
+    then the shell configured system-wide will be used, but you can also use the header line to write
+    script in another language (like #!/bin/perl) or control the options that shell uses.
+    Default shell is the same as configured for the Execute shell build step.
+
+    <p>
+    By default, the shell will be invoked with the "-ex" option. So all of the commands are printed
+    before being executed, and the build is considered a failure if any of the commands exits with
+    a non-zero exit code. Again, add the #!/bin/... line to change this behavior.
+
+    <p>
+    As a best practice, try not to put a long shell script in here. Instead, consider adding the shell
+    script in SCM and simply call that shell script from Jenkins (via bash -ex myscript.sh or something like that),
+    so that you can track changes in your shell script.
+</div>


### PR DESCRIPTION
This adds the ability to execute a shell script to determine if a job in a MultiJob phase should run.

For example, say you have a MultiJob phase with jobs alpha, bravo, and charlie.  Based on a build parameter, you do not want to execute the bravo job sometimes.  Before this change, this was really hard to do.
You'd either need to do some fancy job setup with the run-condition plugin (two conditional phases, one with bravo and one without).  Or you'd have to call bravo regardless and have it stop itself before running.

With this change, you can control whether a job runs with a simple command script.  If the script exits with a non-zero exit status, the job is skipped.  For example:

Run condition command:
```sh
#!/bin/bash -e
[ "$RUN_BRAVO" = "true" ]
```

Because this is a shell command, the possibilities are endless.  You can perform boolean logic on several build variables, read a file on the filesystem, etc.