### PR TITLE
Add throttle groups (sequential execution) within phases

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -30,8 +30,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -151,7 +154,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
         MultiJobBuild multiJobBuild = (MultiJobBuild) build;
         MultiJobProject thisProject = multiJobBuild.getProject();
 
-        Map<PhaseSubJob, PhaseJobsConfig> phaseSubJobs = new HashMap<PhaseSubJob, PhaseJobsConfig>(
+        Map<PhaseSubJob, PhaseJobsConfig> phaseSubJobs = new LinkedHashMap<PhaseSubJob, PhaseJobsConfig>(
                 phaseJobs.size());
 
         for (PhaseJobsConfig phaseJobConfig : phaseJobs) {
@@ -162,7 +165,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             }
         }
 
-        List<SubTask> subTasks = new ArrayList<SubTask>();
+        Queue<SubTask> subTaskQueue = new LinkedList<SubTask>();
         for (PhaseSubJob phaseSubJob : phaseSubJobs.keySet()) {
             AbstractProject subJob = phaseSubJob.job;
             if (subJob.isDisabled()) {
@@ -171,6 +174,11 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             }
 
             PhaseJobsConfig phaseConfig = phaseSubJobs.get(phaseSubJob);
+
+            if (phaseConfig.isDisableJob()) {
+                listener.getLogger().println(String.format("Warning: %s subjob is disabled.", subJob.getName()));
+                continue;
+            }
 
             if (phaseConfig.getEnableCondition() && phaseConfig.getCondition() != null) {
                 if (!evalCondition(phaseConfig.getCondition(), build, listener)) {
@@ -183,46 +191,95 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             		continue;
             	}
             }
-            reportStart(listener, subJob);
+
+            String throttleGroup = null;
+            if (phaseConfig.getEnableThrottleGroup() && phaseConfig.getThrottleGroup() != null) {
+                throttleGroup = expandToken(phaseConfig.getThrottleGroup(), build, listener).trim();
+                // treat blank and false throttle groups as none
+                if (throttleGroup.equals("") || throttleGroup.equals("false")) {
+                    throttleGroup = null;
+                }
+            }
+
             List<Action> actions = new ArrayList<Action>();
             prepareActions(multiJobBuild, subJob, phaseConfig, listener, actions);
 
-            while (subJob.isInQueue()) {
-                TimeUnit.SECONDS.sleep(subJob.getQuietPeriod());
-            }
-
-            if (!phaseConfig.isDisableJob()) {
-                subTasks.add(new SubTask(subJob, phaseConfig, actions, multiJobBuild));
-            } else {
-                listener.getLogger().println(String.format("Warning: %s subjob is disabled.", subJob.getName()));
-            }
+            subTaskQueue.add(new SubTask(subJob, throttleGroup, phaseConfig, actions, multiJobBuild));
         }
 
-        if (subTasks.size() < 1)
+        if (subTaskQueue.size() < 1)
             return true;
 
-        ExecutorService executor = Executors.newFixedThreadPool(subTasks.size());
-        Set<Result> jobResults = new HashSet<Result>();
-        BlockingQueue<SubTask> queue = new ArrayBlockingQueue<SubTask>(subTasks.size());
-        for (SubTask subTask : subTasks) {
-            Runnable worker = new SubJobWorker(thisProject, listener, subTask, queue);
-            executor.execute(worker);
+        // calculate the number of executors we'll need: one for each throttle group
+        // plus one for every task without a throttle group
+        int numExecutors = 0;
+        Set seenThrottleGroups = new HashSet<String>();
+        for (SubTask subTask : subTaskQueue) {
+            if (subTask.throttleGroup == null) {
+                numExecutors++;
+            } else if (!seenThrottleGroups.contains(subTask.throttleGroup)) {
+                seenThrottleGroups.add(subTask.throttleGroup);
+                numExecutors++;
+            }
         }
 
+        // subTasks holds a list of jobs that have been submitted for execution
+        List<SubTask> subTasks = new ArrayList<SubTask>();
+        Set<Result> jobResults = new HashSet<Result>();
+        ExecutorService executor = Executors.newFixedThreadPool(numExecutors);
+        BlockingQueue<SubTask> executeQueue = new ArrayBlockingQueue<SubTask>(numExecutors);
+        Set executorThrottleGroups = new HashSet<String>(numExecutors - 1);
+
         try {
-            executor.shutdown();
             int resultCounter = 0;
             while (!executor.isTerminated()) {
-                SubTask subTask = queue.poll(5, TimeUnit.SECONDS);
+                if (subTaskQueue.isEmpty()) {
+                    if (subTasks.size() <= resultCounter) {
+                        break;
+                    }
+                } else {
+                    // Add executors for open throttle groups
+                    Iterator<SubTask> it = subTaskQueue.iterator();
+                    while(it.hasNext()) {
+                        SubTask subTask = it.next();
+
+                        if (subTask.throttleGroup != null) {
+                            if (executorThrottleGroups.contains(subTask.throttleGroup)) {
+                                continue;
+                            }
+                            // Occupy a spot in the executorThrottleGroups so no other subTasks
+                            // in this throttle group may execute until this one completes
+                            executorThrottleGroups.add(subTask.throttleGroup);
+                        }
+
+                        // Remove the subTask from the queue since we are submitting it for execution
+                        it.remove();
+
+                        reportStart(listener, subTask.subJob);
+                        subTask.GenerateFuture();
+                        subTasks.add(subTask);
+                        Runnable worker = new SubJobWorker(thisProject, listener, subTask, executeQueue);
+                        executor.execute(worker);
+                    }
+
+                    // Once all jobs have been submitted for execution, disallow further subTasks
+                    // from executing
+                    if (subTaskQueue.isEmpty()) {
+                        executor.shutdown();
+                    }
+                }
+
+                SubTask subTask = executeQueue.poll(5, TimeUnit.SECONDS);
+
                 if (subTask != null) {
                     resultCounter++;
+                    if (subTask.throttleGroup != null) {
+                        executorThrottleGroups.remove(subTask.throttleGroup);
+                    }
                     if (subTask.result != null) {
                         jobResults.add(subTask.result);
                         checkPhaseTermination(subTask, subTasks, listener);
                     }
-                }
-                if (subTasks.size() <= resultCounter) {
-                    break;
                 }
             }
 

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
@@ -59,6 +59,8 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 	private List<AbstractBuildParameters> configs;
 	private KillPhaseOnJobResultCondition killPhaseOnJobResultCondition = KillPhaseOnJobResultCondition.NEVER;
 	private boolean buildOnlyIfSCMChanges = false;
+	private boolean enableThrottleGroup;
+	private String throttleGroup;
 
 	public boolean isBuildOnlyIfSCMChanges() {
 		return this.buildOnlyIfSCMChanges;
@@ -173,13 +175,30 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 		return getClass().getSimpleName();
 	}
 
+	public void setThrottleGroup(String throttleGroup) {
+		this.throttleGroup = throttleGroup;
+	}
+
+	public String getThrottleGroup() {
+		return this.throttleGroup;
+	}
+
+	public void setEnableThrottleGroup(boolean enableThrottleGroup) {
+		this.enableThrottleGroup = enableThrottleGroup;
+	}
+
+	public boolean getEnableThrottleGroup() {
+		return enableThrottleGroup;
+	}
+
 	@DataBoundConstructor
 	public PhaseJobsConfig(String jobName, String jobProperties,
 			boolean currParams, List<AbstractBuildParameters> configs,
 			KillPhaseOnJobResultCondition killPhaseOnJobResultCondition,
 			boolean disableJob, boolean enableRetryStrategy,
 			String parsingRulesPath, int maxRetries, boolean enableCondition,
-			boolean abortAllJob, String condition, boolean buildOnlyIfSCMChanges) {
+			boolean abortAllJob, String condition, boolean buildOnlyIfSCMChanges,
+			boolean enableThrottleGroup, String throttleGroup) {
 		this.jobName = jobName;
 		this.jobProperties = jobProperties;
 		this.currParams = currParams;
@@ -196,6 +215,8 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 		this.abortAllJob = abortAllJob;
 		this.condition = Util.fixNull(condition);
 		this.buildOnlyIfSCMChanges = buildOnlyIfSCMChanges;
+		this.enableThrottleGroup = enableThrottleGroup;
+		this.throttleGroup = throttleGroup;
 	}
 
 	public List<AbstractBuildParameters> getConfigs() {

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/SubTask.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/SubTask.java
@@ -18,16 +18,17 @@ public final class SubTask {
     final public List<Action> actions;
     public Future<AbstractBuild> future;
     final public MultiJobBuild multiJobBuild;
+    final public String throttleGroup;
     public Result result;
     private boolean cancel;
 
-    SubTask(AbstractProject subJob, PhaseJobsConfig phaseConfig, List<Action> actions, MultiJobBuild multiJobBuild) {
+    SubTask(AbstractProject subJob, String throttleGroup, PhaseJobsConfig phaseConfig, List<Action> actions, MultiJobBuild multiJobBuild) {
         this.subJob = subJob;
+        this.throttleGroup = throttleGroup;
         this.phaseConfig = phaseConfig;
         this.actions = actions;
         this.multiJobBuild = multiJobBuild;
         this.cancel = false;
-        GenerateFuture();
     }
 
     public boolean isCancelled() {

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
@@ -50,6 +50,13 @@
                         </f:entry>
                     </f:block>
                 </f:optionalBlock>
+                <f:optionalBlock title="Enable throttle group" name="enableThrottleGroup" inline="true" checked="${instance.enableThrottleGroup}" help="/plugin/jenkins-multijob-plugin/help-throttleGroup.html">
+                    <f:block>
+                        <f:entry title="Throttle group" field="throttleGroup">
+                            <f:textbox name="throttleGroup" default="" />
+                        </f:entry>
+                    </f:block>
+                </f:optionalBlock>
                 <f:block>
                     <f:hetero-list name="configs" hasHeader="true"
                        descriptors="${descriptor.getBuilderConfigDescriptors()}"

--- a/src/main/webapp/help-throttleGroup.html
+++ b/src/main/webapp/help-throttleGroup.html
@@ -1,0 +1,22 @@
+<div>
+	A throttle group restricts which jobs can run in parallel.  All jobs with identical
+	throttle groups will run in series rather than parallel.
+
+	<p>
+	By default, all jobs within a phase run in parallel.  So if you have jobs A, B, and C -
+	they will all execute in parallel.  This looks like:
+	<pre>
+  A......
+  B........
+  C...
+  </pre>
+
+	<p>
+	With throttle groups, you can assign the same string to jobs A and C.  This will cause
+	C to wait until A finishes executing before it starts.  This would look like:
+	<pre>
+  A......
+  B........
+         C...
+  </pre>
+</div>

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
@@ -52,14 +52,14 @@ public class ConditionalPhaseTest {
         final MultiJobProject multi = j.jenkins.createProject(MultiJobProject.class, "MultiTop");
 
         // create 'FirstPhase' containing job 'free'
-        PhaseJobsConfig firstPhase = new PhaseJobsConfig("free", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+        PhaseJobsConfig firstPhase = new PhaseJobsConfig("free", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false, "");
         List<PhaseJobsConfig> configTopList = new ArrayList<PhaseJobsConfig>();
         configTopList.add(firstPhase);
         MultiJobBuilder firstPhaseBuilder = new MultiJobBuilder("FirstPhase", configTopList, ContinuationCondition.SUCCESSFUL);
         
         
         // create 'SecondPhase' containing job 'free2'
-        PhaseJobsConfig secondPhase = new PhaseJobsConfig("free2", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+        PhaseJobsConfig secondPhase = new PhaseJobsConfig("free2", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false, "");
         List<PhaseJobsConfig> configTopList2 = new ArrayList<PhaseJobsConfig>();
         configTopList.add(secondPhase);
         MultiJobBuilder secondPhaseBuilder = new MultiJobBuilder("SecondPhase", configTopList2, ContinuationCondition.SUCCESSFUL);

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/PhaseJobsConfigTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/PhaseJobsConfigTest.java
@@ -81,7 +81,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(null);
 		MultiJobBuild mjb =createTriggeringBuild(null);
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "" , true);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "" , true, false, "");
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 		// check single ParametersAction created
@@ -93,7 +93,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(null);
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false, "");
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
 		// check single ParametersAction created
@@ -113,7 +113,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(createParametersAction(CURRENT_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "" , false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "" , false, false, "");
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
@@ -136,7 +136,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(createParametersAction(OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false, "");
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
@@ -158,7 +158,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(createParametersAction(OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false, "");
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, false);
 
 		// check single ParametersAction created
@@ -181,7 +181,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		configs.add(new TestParametersConfig());
 		configs.add(new TestParametersConfig(OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false, "");
 
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
@@ -210,7 +210,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		configs.add(new TestParametersConfig());
 		configs.add(new TestParametersConfig(CONFIG_OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false, "");
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
@@ -239,7 +239,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		configs.add(new TestParametersConfig());
 		configs.add(new TestParametersConfig(CONFIG_OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false, "");
 
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, false);


### PR DESCRIPTION
Throttle groups allow you to execute specific jobs within a phase in serial.  For example, if you have jobs A, B, and C, the default behavior executes them in parallel, for example:

    A....
    B......
    C...

If we assign the same "throttle group" (a string) to jobs A and C, they will execute in series (C will not start until A finishes).  This would look like:

    A....
    B......
         C...

Throttle groups add another level of customization to MultiJobs.  They support variable expansion and treat the "false" string as no throttle group - so they can be easily attached to boolean build parameters.