### PR TITLE
Fix the polling method, making it more Jenkins API - friendly

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -67,23 +67,23 @@ import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import groovy.util.*;
 
 public class MultiJobBuilder extends Builder implements DependecyDeclarer {
-	/**
-	 * The name of the parameter in the build.getBuildVariables() to enable the job build, regardless
-	 * of scm changes.
-	 */
+    /**
+     * The name of the parameter in the build.getBuildVariables() to enable the job build, regardless
+     * of scm changes.
+     */
 
-	public static final String BUILD_ALWAYS_KEY = "hudson.scm.multijob.build.always";
-	/**
-	 * List of messages to show by console.
-	 */
-	private static final String[]  TRIGGER_MESSAGES = {
-		"    >> [%s] added to build queue.\n",
-		"    >> [%s] has changes since last build. Adding to build queue.\n",
-		"    >> [%s] has no changes since last build, but it will be adding to build queue.\n",
-		"    >> [%s] has no changes since last build, but you have enabled the 'build always' function. Adding to build queue.\n",
-		"    >> [%s] has no changes since last build, so it will be skipped.\n",
-		"    >> [%s] has been disabled. Skipping it.\n"
-	};
+    public static final String BUILD_ALWAYS_KEY = "hudson.scm.multijob.build.always";
+    /**
+     * List of messages to show by console.
+     */
+    private static final String[]  TRIGGER_MESSAGES = {
+        "    >> [%s] added to build queue.\n",
+        "    >> [%s] has changes since last build. Adding to build queue.\n",
+        "    >> [%s] has no changes since last build, but it will be adding to build queue.\n",
+        "    >> [%s] has no changes since last build, but you have enabled the 'build always' function. Adding to build queue.\n",
+        "    >> [%s] has no changes since last build, so it will be skipped.\n",
+        "    >> [%s] has been disabled. Skipping it.\n"
+    };
 
 
     private String phaseName;
@@ -111,29 +111,26 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
 
         return matcher.replaceAll("");
     }
-    private int getScmChange(AbstractProject subjob,PhaseJobsConfig phaseConfig,AbstractBuild build, BuildListener listener,Launcher launcher) throws IOException, InterruptedException{
-    	final boolean containsLastBuild = ( subjob.getLastBuild() != null );
-		final SCM scm = subjob.getScm();
-		final SCMRevisionState scmRS = ( containsLastBuild ? scm.calcRevisionsFromBuild((AbstractBuild) subjob.getLastBuild(), launcher, listener) : null );
-		final boolean hasChanges = ( containsLastBuild ? scm.poll(subjob, launcher, subjob.getWorkspace(), listener, scmRS).hasChanges() : true );
+    private int getScmChange(AbstractProject subjob, PhaseJobsConfig phaseConfig, AbstractBuild build, BuildListener listener,Launcher launcher) throws IOException, InterruptedException{
+        final boolean buildOnlyIfSCMChanges = phaseConfig.isBuildOnlyIfSCMChanges();
+        final boolean buildAlways = Boolean.valueOf((String)(build.getBuildVariables().get(BUILD_ALWAYS_KEY)));
+        final boolean containsLastBuild = subjob.getLastBuild() != null;
+        final boolean hasChanges = !containsLastBuild || subjob.poll(listener).hasChanges();
 
-		final boolean buildOnlyIfSCMChanges = phaseConfig.isBuildOnlyIfSCMChanges();
-		final boolean buildAlways = Boolean.valueOf((String)(build.getBuildVariables().get(BUILD_ALWAYS_KEY)));
-
-		final int message = 
-			(!buildOnlyIfSCMChanges)
-				? 0
-				: (hasChanges
-					? 1
-					: (!buildOnlyIfSCMChanges
-						? 2
-						: ((buildAlways) ? 3 : 4)
-					)
-				);
-		listener.getLogger().printf(TRIGGER_MESSAGES[message], subjob.getName());
-	    return message; 
-
+        final int message = 
+            (!buildOnlyIfSCMChanges)
+                ? 0
+                : (hasChanges
+                    ? 1
+                    : (!buildOnlyIfSCMChanges
+                        ? 2
+                        : ((buildAlways) ? 3 : 4)
+                    )
+                );
+        listener.getLogger().printf(TRIGGER_MESSAGES[message], subjob.getName());
+        return message; 
     }
+
     public boolean evalCondition(final String condition, final AbstractBuild<?, ?> build, final BuildListener listener) {
         try {
             return (Boolean) Eval.me(expandToken(condition, build, listener).toLowerCase().trim());
@@ -179,9 +176,9 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                 }
             }
             if (phaseConfig.isBuildOnlyIfSCMChanges()){
-            	if( getScmChange(subJob,phaseConfig,multiJobBuild ,listener,launcher ) >= 4) {
-            		continue;
-            	}
+                if( getScmChange(subJob,phaseConfig,multiJobBuild ,listener,launcher ) >= 4) {
+                    continue;
+                }
             }
             reportStart(listener, subJob);
             List<Action> actions = new ArrayList<Action>();
@@ -283,7 +280,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                     retry++;
                     QueueTaskFuture<AbstractBuild> future = (QueueTaskFuture<AbstractBuild>) subTask.future;
                     while (true) {
-                    	if (subTask.isCancelled()) {
+                        if (subTask.isCancelled()) {
                             if (jobBuild != null) {
                                 Executor exect = jobBuild.getExecutor();
                                 if (exect != null) {

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -85,7 +85,6 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
         "    >> [%s] has been disabled. Skipping it.\n"
     };
 
-
     private String phaseName;
     private List<PhaseJobsConfig> phaseJobs;
     private ContinuationCondition continuationCondition = ContinuationCondition.SUCCESSFUL;
@@ -114,8 +113,8 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
     private int getScmChange(AbstractProject subjob, PhaseJobsConfig phaseConfig, AbstractBuild build, BuildListener listener,Launcher launcher) throws IOException, InterruptedException{
         final boolean buildOnlyIfSCMChanges = phaseConfig.isBuildOnlyIfSCMChanges();
         final boolean buildAlways = Boolean.valueOf((String)(build.getBuildVariables().get(BUILD_ALWAYS_KEY)));
-        final boolean containsLastBuild = subjob.getLastBuild() != null;
-        final boolean hasChanges = !containsLastBuild || subjob.poll(listener).hasChanges();
+        final boolean containsLastBuild = buildAlways ? false : subjob.getLastBuild() != null;
+        final boolean hasChanges = buildAlways ? false : !containsLastBuild || subjob.poll(listener).hasChanges();
 
         final int message = 
             (!buildOnlyIfSCMChanges)

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -85,6 +85,8 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
         "    >> [%s] has been disabled. Skipping it.\n"
     };
 
+    private static final Pattern PATTERN = Pattern.compile("(\\$\\{.+?\\})", Pattern.CASE_INSENSITIVE);
+
     private String phaseName;
     private List<PhaseJobsConfig> phaseJobs;
     private ContinuationCondition continuationCondition = ContinuationCondition.SUCCESSFUL;
@@ -105,8 +107,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             listener.getLogger().println(e.getMessage());
         }
 
-        Pattern pattern = Pattern.compile("(\\$\\{.+?\\})", Pattern.CASE_INSENSITIVE);
-        Matcher matcher = pattern.matcher(expandedExpression);
+        Matcher matcher = PATTERN.matcher(expandedExpression);
 
         return matcher.replaceAll("");
     }


### PR DESCRIPTION
This patch simplify the getScmChange method, making it more Jenkins friendly, and minimizing the complexity of decisions.