### PR TITLE
don't downcase the conditional in multijob job [JENKINS-27025]

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -133,7 +133,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
 
     public boolean evalCondition(final String condition, final AbstractBuild<?, ?> build, final BuildListener listener) {
         try {
-            return (Boolean) Eval.me(expandToken(condition, build, listener).toLowerCase().trim());
+            return (Boolean) Eval.me(expandToken(condition, build, listener).trim());
         } catch (Exception e) {
             listener.getLogger().println("Can't evaluate expression, false is assumed.");
             listener.getLogger().println(e.toString());


### PR DESCRIPTION
Hi, this is a fix for https://issues.jenkins-ci.org/browse/JENKINS-27025

I have not tested it but I see no reasons why this would not work.