### PR TITLE
Re arranging column, in same as viewed with Jenkins

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobListViewColumn.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobListViewColumn.java
@@ -33,7 +33,7 @@ abstract public class MultiJobListViewColumn extends ListViewColumn {
     }
 
     @SuppressWarnings("unchecked")
-    private static final List<Class<? extends ListViewColumn>> DEFAULT_COLUMNS = Arrays.asList(StatusColumn.class, JobColumn.class, WeatherColumn.class,
+    private static final List<Class<? extends ListViewColumn>> DEFAULT_COLUMNS = Arrays.asList(StatusColumn.class, WeatherColumn.class, JobColumn.class,
             LastSuccessColumn.class, LastFailureColumn.class, LastDurationColumn.class, ConsoleColumn.class, BuildButtonColumn.class);
 
     private static final Logger LOGGER = Logger.getLogger(MultiJobListViewColumn.class.getName());

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobListViewColumn.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobListViewColumn.java
@@ -33,7 +33,7 @@ abstract public class MultiJobListViewColumn extends ListViewColumn {
     }
 
     @SuppressWarnings("unchecked")
-    private static final List<Class<? extends ListViewColumn>> DEFAULT_COLUMNS = Arrays.asList(JobColumn.class, StatusColumn.class, WeatherColumn.class,
+    private static final List<Class<? extends ListViewColumn>> DEFAULT_COLUMNS = Arrays.asList(StatusColumn.class, JobColumn.class, WeatherColumn.class,
             LastSuccessColumn.class, LastFailureColumn.class, LastDurationColumn.class, ConsoleColumn.class, BuildButtonColumn.class);
 
     private static final Logger LOGGER = Logger.getLogger(MultiJobListViewColumn.class.getName());


### PR DESCRIPTION
Jenkins is showing Status column as 1st Column. 
We are using "Canon-Rackspace" theme on our Jenkins environment.
Which consider 1st column as status column and apply status specific css on 1st column, which is in case of Multi job is job name.
As a consistency in Jenkins we should maintain it or have a flexibility to make it compatible.

![2](https://cloud.githubusercontent.com/assets/5267739/8067303/72548a68-0f0a-11e5-97bf-4f827074df8f.png)
