### PR TITLE
[JENKINS-29229] Fixed (and added) environment variables

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -597,6 +597,18 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
         String buildNumber = Integer.toString(jobBuild.getNumber());
         String buildResult = jobBuild.getResult().toString();
 
+        // If the job is run a second time, store the first job's number and result with unique keys
+        if (variables.get("TRIGGERED_BUILD_RUN_COUNT_" + jobNameSafe) != null) {
+            String runCount = Integer.toString(Integer.parseInt(variables
+                    .get("TRIGGERED_BUILD_RUN_COUNT_" + jobNameSafe)));
+            if (runCount.equals("1")) {
+                String firstBuildNumber = variables.get(jobNameSafe + "_BUILD_NUMBER");
+                String firstBuildResult = variables.get(jobNameSafe + "_BUILD_RESULT");
+                variables.put(jobNameSafe + "_" + runCount + "_BUILD_NUMBER", firstBuildNumber);
+                variables.put(jobNameSafe + "_" + runCount + "_BUILD_RESULT", firstBuildResult);
+            }
+        }
+
         // These will always reference the last build
         variables.put("LAST_TRIGGERED_JOB_NAME", jobName);
         variables.put(jobNameSafe + "_BUILD_NUMBER", buildNumber);
@@ -616,6 +628,8 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             String runCount = Integer.toString(Integer.parseInt(variables
                     .get("TRIGGERED_BUILD_RUN_COUNT_" + jobNameSafe)) + 1);
             variables.put("TRIGGERED_BUILD_RUN_COUNT_" + jobNameSafe, runCount);
+            variables.put(jobNameSafe + "_" + runCount + "_BUILD_NUMBER", buildNumber);
+            variables.put(jobNameSafe + "_" + runCount + "_BUILD_RESULT", buildResult);
         }
 
         // Set the new build variables map

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -572,6 +572,25 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
         // Env variables map
         Map<String, String> variables = new HashMap<String, String>();
 
+        // Fetch the map of existing environment variables
+        try {
+
+            EnvInjectLogger logger = new EnvInjectLogger(listener);
+            EnvInjectVariableGetter variableGetter = new EnvInjectVariableGetter();
+            Map<String, String> previousEnvVars = variableGetter
+                    .getEnvVarsPreviousSteps(thisBuild, logger);
+
+            // Get current envVars
+            variables = new HashMap<String, String>(
+                    previousEnvVars);
+
+        } catch (Throwable throwable) {
+            listener.getLogger()
+                    .println(
+                            "[MultiJob] - [ERROR] - Problems occurs on fetching env vars as a build step: "
+                                    + throwable.getMessage());
+        }
+
         String jobName = jobBuild.getProject().getName();
         String jobNameSafe = jobName.replaceAll("[^A-Za-z0-9]", "_")
                 .toUpperCase();


### PR DESCRIPTION
There is a bug in addBuildEnvironmentVariables that means that some of the variables are not updated correctly. The code creates an empty HashMap every time it is executed, but is attempting to find variables in it from previous calls.

The fix is to pull the existing environment variables into the local HashMap at the start of addBuildEnvironmentVariables.

I addition, I've added some extra variables - [job name]_[run instance]_BUILD_NUMBER/RESULT (one for each instance of a job when run multiple times) - similar to the ones used in the parameterized trigger plugin. The variables are only added when a job is run multiple times.

Neither of these changes affect the existing [job name]_BUILD_NUMBER/RESULT variables, which still reference the last job executed, so shouldn't break compatibility with existing configurations.