### PR TITLE
[FIXED JENKINS-30262] - Always use absolute URLs in MultiJob's JobColumn

### DIFF
--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/views/JobColumn/column.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/views/JobColumn/column.jelly
@@ -7,7 +7,7 @@
 				${job.isConditional() ? "[?]" : ""} ${job.displayName}
 			</j:when>
 			<j:when test="${!job.phase}">
-				<a href="${jobBaseUrl}${job.shortUrl}">${job.displayName}</a>
+				<a href="${job.absoluteUrl}">${job.displayName}</a>
 			</j:when>
 		</j:choose>
 	</td>


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-30262

The change replaces the implementation to Job's absolute url in order to always produce a valid link. The original approach does not work in general, because Views may not contain the multijob's items => relative paths may be broken.

Ridiculously, there's the same glitch in /lib/hudson/jobLink for the supported version core. It needs to be investigated separately.

@reviewbybees @hagzag 