### PR TITLE
EzTemplate (similar to Conditional Plugin) support added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>com.joelj.jenkins</groupId>
 			<artifactId>ez-templates</artifactId>
-			<version>1.0.4</version>
+			<version>1.0-SNAPSHOT</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>com.joelj.jenkins</groupId>
 			<artifactId>ez-templates</artifactId>
-			<version>1.1</version>
+			<version>1.0.5</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>com.joelj.jenkins</groupId>
 			<artifactId>ez-templates</artifactId>
-			<version>1.0-SNAPSHOT</version>
+			<version>1.1</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.joelj.jenkins</groupId>
+			<artifactId>ez-templates</artifactId>
+			<version>1.0.4</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>token-macro</artifactId>
 			<version>1.10</version>

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobView.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobView.java
@@ -1,5 +1,6 @@
 package com.tikal.jenkins.plugins.multijob.views;
 
+import com.joelj.jenkins.eztemplates.InheritenceStep.EzTemplateBuilder;
 import hudson.Extension;
 import hudson.Indenter;
 import hudson.Util;
@@ -121,6 +122,16 @@ public class MultiJobView extends ListView {
             if (builder instanceof MultiJobBuilder) {
                 addProjectFromBuilder(project, buildState, out, builder,
                         phaseNestLevel, false);
+            }
+
+            else if (builder instanceof EzTemplateBuilder) {
+                final List<BuildStep> conditionalbuilders = ((EzTemplateBuilder) builder).getConditionalbuilders();
+                for (BuildStep buildStep : conditionalbuilders) {
+                    if (buildStep instanceof MultiJobBuilder) {
+                        addProjectFromBuilder(project, buildState, out,
+                                buildStep, phaseNestLevel, true);
+                    }
+                }
             }
 
             else if (builder instanceof ConditionalBuilder) {


### PR DESCRIPTION
I want to use ezTemplate Plugin which is used for templating jobs.
EzTemplate plugin is very useful for use as templated job, It has a similar functionality as conditional buildstep plugin.
As we can see Multijob view for conditional build steps. 
As this plugin has a custom implementation to view conditional build step.
I also want to add same behavior for ezTemplate plugin.

There is a side impact that is :We will have another dependency for ezTemplate plugin in this plugin. :-1: 

For reference :
https://github.com/JoelJ/ez-templates/issues/52
https://github.com/JoelJ/ez-templates/pull/54