### PR TITLE
Other jobs should be aborted only if it configured in phase

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -594,7 +594,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                 return false;
             }
             if (killCondition.isKillPhase(subTask.result)) {
-                if (subTask.result != Result.ABORTED || subTask.phaseConfig.getAbortAllJob()) {
+                if (subTask.result != Result.ABORTED && subTask.phaseConfig.getAbortAllJob()) {
                     for (SubTask _subTask : subTasks) {
                         _subTask.cancelJob();
                     }


### PR DESCRIPTION
Let we have several jobs in one phase. Each job is configured not to abort the remaining jobs.
But currently, if one of these jobs completed with status FAILED, then other jobs are cancelled.

So, if "Abort all other jobs" isn't checked then the remianing jobs should continue execution

![Image]
(http://s21.postimg.org/3pixtinuv/Screen_Shot_2015_11_17_at_15_02_34.png)