### PR TITLE
add an option to eval the phase condition only when no SCM changes were found

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
@@ -59,6 +59,7 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 	private List<AbstractBuildParameters> configs;
 	private KillPhaseOnJobResultCondition killPhaseOnJobResultCondition = KillPhaseOnJobResultCondition.NEVER;
 	private boolean buildOnlyIfSCMChanges = false;
+	private boolean applyConditionOnlyIfNoSCMChanges = false;
 
 	public boolean isBuildOnlyIfSCMChanges() {
 		return this.buildOnlyIfSCMChanges;
@@ -66,6 +67,14 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 
 	public void setBuildOnlyIfSCMChanges(boolean triggerOnlyIfSCMChanges) {
 		this.buildOnlyIfSCMChanges = triggerOnlyIfSCMChanges;
+	}
+
+	public boolean isApplyConditionOnlyIfNoSCMChanges() {
+		return this.applyConditionOnlyIfNoSCMChanges;
+	}
+
+	public void setApplyConditionOnlyIfNoSCMChanges(boolean applyConditionOnlyIfNoSCMChanges) {
+		this.applyConditionOnlyIfNoSCMChanges = applyConditionOnlyIfNoSCMChanges;
 	}
 
 	public void setParsingRulesPath(String parsingRulesPath) {
@@ -179,7 +188,7 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 			KillPhaseOnJobResultCondition killPhaseOnJobResultCondition,
 			boolean disableJob, boolean enableRetryStrategy,
 			String parsingRulesPath, int maxRetries, boolean enableCondition,
-			boolean abortAllJob, String condition, boolean buildOnlyIfSCMChanges) {
+			boolean abortAllJob, String condition, boolean buildOnlyIfSCMChanges, boolean applyConditionOnlyIfNoSCMChanges) {
 		this.jobName = jobName;
 		this.jobProperties = jobProperties;
 		this.currParams = currParams;
@@ -196,6 +205,7 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 		this.abortAllJob = abortAllJob;
 		this.condition = Util.fixNull(condition);
 		this.buildOnlyIfSCMChanges = buildOnlyIfSCMChanges;
+		this.applyConditionOnlyIfNoSCMChanges = applyConditionOnlyIfNoSCMChanges;
 	}
 
 	public List<AbstractBuildParameters> getConfigs() {

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
@@ -48,7 +48,7 @@
                         <f:entry title="Condition" field="condition">
                             <f:textbox name="condition" default="" />
                         </f:entry>
-                        <f:entry>
+                        <f:entry help="/plugin/jenkins-multijob-plugin/help-applyCondition.html">
                             <f:checkbox field="applyConditionOnlyIfNoSCMChanges" name="applyConditionOnlyIfNoSCMChanges" checked="${instance.applyConditionOnlyIfNoSCMChanges}" default="false"/>
                             <label class="attach-previous">Apply condition only if no SCM changes were found</label>
                         </f:entry>

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
@@ -48,6 +48,10 @@
                         <f:entry title="Condition" field="condition">
                             <f:textbox name="condition" default="" />
                         </f:entry>
+                        <f:entry>
+                            <f:checkbox field="applyConditionOnlyIfNoSCMChanges" name="applyConditionOnlyIfNoSCMChanges" checked="${instance.applyConditionOnlyIfNoSCMChanges}" default="false"/>
+                            <label class="attach-previous">Apply condition only if no SCM changes were found</label>
+                        </f:entry>
                     </f:block>
                 </f:optionalBlock>
                 <f:block>

--- a/src/main/webapp/help-applyCondition.html
+++ b/src/main/webapp/help-applyCondition.html
@@ -1,0 +1,4 @@
+<div>
+    Apply the condition only if no SCM changes were found.<br />
+    <b>NOTE:</b> it is only active when "Build only if SCM changes" is checked.<br />
+</div>

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
@@ -52,14 +52,14 @@ public class ConditionalPhaseTest {
         final MultiJobProject multi = j.jenkins.createProject(MultiJobProject.class, "MultiTop");
 
         // create 'FirstPhase' containing job 'free'
-        PhaseJobsConfig firstPhase = new PhaseJobsConfig("free", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+        PhaseJobsConfig firstPhase = new PhaseJobsConfig("free", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
         List<PhaseJobsConfig> configTopList = new ArrayList<PhaseJobsConfig>();
         configTopList.add(firstPhase);
         MultiJobBuilder firstPhaseBuilder = new MultiJobBuilder("FirstPhase", configTopList, ContinuationCondition.SUCCESSFUL);
         
         
         // create 'SecondPhase' containing job 'free2'
-        PhaseJobsConfig secondPhase = new PhaseJobsConfig("free2", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+        PhaseJobsConfig secondPhase = new PhaseJobsConfig("free2", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
         List<PhaseJobsConfig> configTopList2 = new ArrayList<PhaseJobsConfig>();
         configTopList.add(secondPhase);
         MultiJobBuilder secondPhaseBuilder = new MultiJobBuilder("SecondPhase", configTopList2, ContinuationCondition.SUCCESSFUL);

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/PhaseJobsConfigTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/PhaseJobsConfigTest.java
@@ -81,7 +81,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(null);
 		MultiJobBuild mjb =createTriggeringBuild(null);
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "" , true);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "" , true, false);
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 		// check single ParametersAction created
@@ -93,7 +93,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(null);
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
 		// check single ParametersAction created
@@ -113,7 +113,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(createParametersAction(CURRENT_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "" , false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "" , false, false);
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
@@ -136,7 +136,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(createParametersAction(OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
@@ -158,7 +158,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(createParametersAction(OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, false);
 
 		// check single ParametersAction created
@@ -181,7 +181,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		configs.add(new TestParametersConfig());
 		configs.add(new TestParametersConfig(OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
 
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
@@ -210,7 +210,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		configs.add(new TestParametersConfig());
 		configs.add(new TestParametersConfig(CONFIG_OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
@@ -239,7 +239,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		configs.add(new TestParametersConfig());
 		configs.add(new TestParametersConfig(CONFIG_OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
 
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, false);


### PR DESCRIPTION
This is good for scenarios where you check the "Build only if SCM changes" and you have a condition enabled, but you want the condition to be evaluated only if there were no SCM changes.
If SCM changes were found, the build should run regardless of the condition.