### PR TITLE
Add listener to start and complete child jobs

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -392,6 +392,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                 while ((retry <= maxRetries || retryUsingListener) && !finish) {
                     retry++;
                     QueueTaskFuture<AbstractBuild> future = (QueueTaskFuture<AbstractBuild>) subTask.future;
+                    MultiJobListener.fireOnStart(future.waitForStart(), subTask.multiJobBuild);
                     while (true) {
                         if (subTask.isCancelled()) {
                             if (jobBuild != null) {

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/SubTask.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/SubTask.java
@@ -1,6 +1,5 @@
 package com.tikal.jenkins.plugins.multijob;
 
-
 import hudson.model.Action;
 import hudson.model.Run;
 import hudson.model.Result;

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/listeners/MultiJobListener.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/listeners/MultiJobListener.java
@@ -15,7 +15,15 @@ import jenkins.model.Jenkins;
  */
 public abstract class MultiJobListener implements ExtensionPoint {
 
+	public abstract void onStart(AbstractBuild<?, ?> build, MultiJobBuild multiJobBuild);
+
 	public abstract boolean isComplete(AbstractBuild<?, ?> build, MultiJobBuild multiJobBuild);
+
+	public static void fireOnStart(AbstractBuild<?, ?> build, MultiJobBuild multiJobBuild) {
+		for (MultiJobListener l : all()) {
+			l.onStart(build, multiJobBuild);
+		}
+	}
 
 	public static boolean fireOnComplete(AbstractBuild<?, ?> build, MultiJobBuild multiJobBuild) {
 		for (MultiJobListener l : all()) {

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/listeners/MultiJobListener.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/listeners/MultiJobListener.java
@@ -1,0 +1,32 @@
+package com.tikal.jenkins.plugins.multijob.listeners;
+
+import com.tikal.jenkins.plugins.multijob.MultiJobBuild;
+import hudson.ExtensionList;
+import hudson.ExtensionPoint;
+import hudson.model.AbstractBuild;
+import jenkins.model.Jenkins;
+
+/**
+ * Controls which a child job of {@link MultiJobBuild} to rebuild
+ *
+ * <p>
+ * Plugins can implement this extension point to filter out a childs of MultiJob project ti build.
+ * </p>
+ */
+public abstract class MultiJobListener implements ExtensionPoint {
+
+	public abstract boolean isComplete(AbstractBuild<?, ?> build, MultiJobBuild multiJobBuild);
+
+	public static boolean fireOnComplete(AbstractBuild<?, ?> build, MultiJobBuild multiJobBuild) {
+		for (MultiJobListener l : all()) {
+			if (!l.isComplete(build, multiJobBuild)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public static ExtensionList<MultiJobListener> all() {
+		return Jenkins.getInstance().getExtensionList(MultiJobListener.class);
+	}
+}


### PR DESCRIPTION
In some use cases, there is a need to retry the child job within this multi job. The current retry strategy that uses parsing of the console output isn't siutable.
Our use case:
1. We are want to integrate naginator plugin to rerun child job.
2. We are use our plugin, which keeps the job in progress until user fix the configuration in the case of a build failed. After the fix starts a new build.
So, to do this we need to be able to start a new build in the current multijob build.