### PR TITLE
MultiJobBuilder: Synchronize adding the build environment variables

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -677,7 +677,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
     }
 
     @SuppressWarnings("rawtypes")
-    private void addBuildEnvironmentVariables(MultiJobBuild thisBuild,
+    private synchronized void addBuildEnvironmentVariables(MultiJobBuild thisBuild,
             AbstractBuild jobBuild, BuildListener listener) {
         // Env variables map
         Map<String, String> variables = new HashMap<String, String>();


### PR DESCRIPTION
If a single parameterized job is used multiple times (with different
parameters) in the same phase, and that parameterized job is properly set
up to "Execute concurrent builds if necessary", race conditions when
getting / putting the environment variables may occur.

In my test case, I've crerated a (very short running) parameterized job
called "Run-Test-Part". Although I'm running that job 4 times with
different parameters within the same phase, I got

    TRIGGERED_BUILD_RUN_COUNT_RUN_TEST_PART=2

instead of the expected value of 4, because differnet threads passed the

    variables.get("TRIGGERED_BUILD_RUN_COUNT_" + jobNameSafe) != null

check before the variable was put / injected into the environment.

This commit fixes that issue by synchronizing the
addBuildEnvironmentVariables() method.