### PR TITLE
Resume build to include UNSTABLE and ABORTED jobs

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
@@ -134,17 +134,19 @@ public class MultiJobBuild extends Build<MultiJobProject, MultiJobBuild> {
         @Override
         public Result run(BuildListener listener) throws Exception {
             Result result = super.run(listener);
-            MultiJobResumeBuild action = new MultiJobResumeBuild(super.getBuild());
             if (isAborted()) {
-                super.getBuild().addAction(action);
-                return Result.ABORTED;
+                result = Result.ABORTED;
+            } else if (isFailure()) {
+                result = Result.FAILURE;
+            } else if (isUnstable()) {
+                result = Result.UNSTABLE;
             }
-            if (isFailure()) {
+
+            if (!Result.SUCCESS.equals(result)) {
+                MultiJobResumeBuild action = new MultiJobResumeBuild(super.getBuild());
                 super.getBuild().addAction(action);
-                return Result.FAILURE;
             }
-            if (isUnstable())
-                return Result.UNSTABLE;
+
             return result;
         }
 

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -192,7 +192,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
     public boolean perform(final AbstractBuild<?, ? > build, final Launcher launcher, final BuildListener listener) throws InterruptedException, IOException {
         boolean resume = false;
         Map<String, SubBuild> successBuildMap = new HashMap<String, SubBuild>();
-        Map<String, SubBuild> failedBuildMap = new HashMap<String, SubBuild>();
+        Map<String, SubBuild> resumeBuildMap = new HashMap<String, SubBuild>();
         MultiJobResumeControl control = build.getAction(MultiJobResumeControl.class);
         if (null != control) {
             MultiJobBuild prevBuild = (MultiJobBuild) control.getRun();
@@ -203,11 +203,11 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                     AbstractProject childProject = (AbstractProject) item;
                     AbstractBuild childBuild = childProject.getBuildByNumber(subBuild.getBuildNumber());
                     if (null != childBuild) {
-                        if (childBuild.getResult().equals(Result.FAILURE)) {
-                            resume = true;
-                            failedBuildMap.put(childProject.getUrl(), subBuild);
-                        } else {
+                        if (Result.SUCCESS.equals(childBuild.getResult())) {
                             successBuildMap.put(childProject.getUrl(), subBuild);
+                        } else {
+                            resume = true;
+                            resumeBuildMap.put(childProject.getUrl(), subBuild);
                         }
                     }
                 }
@@ -274,7 +274,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             List<Action> actions = new ArrayList<Action>();
 
             if (resume) {
-                SubBuild subBuild = failedBuildMap.get(subJob.getUrl());
+                SubBuild subBuild = resumeBuildMap.get(subJob.getUrl());
                 if (null != subBuild) {
                     AbstractProject prj = Jenkins.getInstance().getItem(subBuild.getJobName(), multiJobBuild.getParent(),
                         AbstractProject.class);


### PR DESCRIPTION
Hi,

I have adapted the resume build feature (#73) to include any job which did not result in SUCCESS. Previously it would only rebuild FAILED jobs and link to the previous build for UNSTABLE or ABORTED jobs.

@sshelomentsev: I'd appreciate if you can review the modifications I have made

Thanks