### PR TITLE
Use absolute url for console link

### DIFF
--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/views/ConsoleColumn/column.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/views/ConsoleColumn/column.jelly
@@ -5,7 +5,7 @@
 	<td data="${lBuild.duration ?: '0'}">
 		<j:choose>
 			<j:when test="${lBuild!=null}">
-				<a href="${jobBaseUrl}${job.shortUrl}${lBuild.number}/console">
+				<a href="${job.absoluteUrl}${lBuild.number}/console">
 					<img src="${imagesURL}/${subIconSize}/terminal.gif" title="${%Console output}"
 						alt="${%Console output}" border="0" />
 				</a>


### PR DESCRIPTION
In the landing page for a Multijob, the link to console output for sub jobs or steps is broken when
* You navigate to it from a non-default view
* and the sub job is in a Folder

This is because the console link uses baseUrl+shortUrl instead of directly using absoluteUrl. 

Steps to reproduce is mentioned in a related issue which is fixed now. [Issue 30262](https://issues.jenkins-ci.org/browse/JENKINS-30262)

