### PR TITLE
Minor fix to only trigger the legacy behavior if no condition is defined

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -264,8 +264,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                 }
             // This is needed because if no condition to eval, the legacy buildOnlyIfSCMChanges feature is still available,
             // so we don't need to change our job configuration.
-            }
-            if ( ! jobStatus.isBuildable() ) {
+            } else if ( ! jobStatus.isBuildable() ) {
                 phaseCounters.processSkipped();
                 continue;
             }


### PR DESCRIPTION
Ran into an issue where I was trying to define a project like:

* Phase 1
 * Job 1
* Phase 2
 * Job 2
 * Job 3
 * Job 4

I was trying to setup the build so that all phase 2 jobs rebuilt any time Job1 was built.  Otherwise, phase 2 jobs only build if SCM changes are detected.

${JOB_IS_BUILDABLE} || ${PHASE_SUCCESSFUL} > 0

The problem I ran into:   If I did not check "Build only if SCM changes", then JOB_IS_BUILDABLE would evaluate to true in cases where there were no changes.  This was causing the phase 2 jobs to build much more often than I wanted.   On the other hand, if I check "Build only if SCM changes", then in the case where a phase 1 job built, it was not forcing the phase 2 jobs to rebuild.   Even though the conditional evaluates to true because "${PHASE_SUCCESSFUL} > 0", in the very next step, it re-evaluates !jobStatus.isBuildable().  Since there are no SCM changes, it skips the build anyhow.

This change just makes the legacy logic only applicable in the case where no conditional is defined.