### PR TITLE
Execution type for multiple jobs in a phase: parallel or sequentially.

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -19,13 +19,19 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Pattern;
@@ -68,7 +74,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
     private String phaseName;
     private List<PhaseJobsConfig> phaseJobs;
     private ContinuationCondition continuationCondition = ContinuationCondition.SUCCESSFUL;
-
+    private ExecutionType executionType = ExecutionType.PARALLEL;
 
     final static Pattern PATTERN = Pattern.compile("(\\$\\{.+?\\})", Pattern.CASE_INSENSITIVE);
 
@@ -102,10 +108,11 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
 
     @DataBoundConstructor
     public MultiJobBuilder(String phaseName, List<PhaseJobsConfig> phaseJobs,
-            ContinuationCondition continuationCondition) {
+            ContinuationCondition continuationCondition, ExecutionType executionType) {
         this.phaseName = phaseName;
         this.phaseJobs = Util.fixNull(phaseJobs);
         this.continuationCondition = continuationCondition;
+        this.executionType = executionType;
     }
 
     public String expandToken(String toExpand, final AbstractBuild<?,?> build, final BuildListener listener) {
@@ -219,7 +226,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
         Jenkins jenkins = Jenkins.getInstance();
         MultiJobBuild multiJobBuild = (MultiJobBuild) build;
         MultiJobProject thisProject = multiJobBuild.getProject();
-        Map<PhaseSubJob, PhaseJobsConfig> phaseSubJobs = new HashMap<PhaseSubJob, PhaseJobsConfig>(
+        Map<PhaseSubJob, PhaseJobsConfig> phaseSubJobs = new LinkedHashMap<PhaseSubJob, PhaseJobsConfig>(
                 phaseJobs.size());
         final CounterManager phaseCounters = new CounterManager();
 
@@ -336,14 +343,27 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             return true;
         }
 
-        ExecutorService executor = Executors.newFixedThreadPool(subTasks.size());
+        int poolSize = executionType.isParallel() ? subTasks.size() : 1;
+        ExecutorService executor = Executors.newFixedThreadPool(poolSize);
         Set<Result> jobResults = new HashSet<Result>();
         BlockingQueue<SubTask> queue = new ArrayBlockingQueue<SubTask>(subTasks.size());
         for (SubTask subTask : subTasks) {
             SubBuild subBuild = successBuildMap.get(subTask.subJob.getUrl());
             if (null == subBuild) {
-                Runnable worker = new SubJobWorker(thisProject, listener, subTask, queue);
-                executor.execute(worker);
+                CompletionService<Boolean> completion = new ExecutorCompletionService<Boolean>(executor);
+                Callable worker = new SubJobWorker(thisProject, listener, subTask, queue);
+                completion.submit(worker);
+                if (!executionType.isParallel()) {
+                    Future<Boolean> future = completion.take();
+                    try {
+                        future.get();
+                        if (checkPhaseTermination(subTask, subTasks, listener)) {
+                            break;
+                        }
+                    } catch (ExecutionException e) {
+                        listener.getLogger().println("Error while execution subtask " + subTask.subJob.getDisplayName());
+                    }
+                }
             } else {
                 AbstractBuild jobBuild = subTask.subJob.getBuildByNumber(subBuild.getBuildNumber());
                 updateSubBuild(multiJobBuild, thisProject, jobBuild, subBuild.getResult());
@@ -393,7 +413,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
         return true;
     }
 
-    public final class SubJobWorker extends Thread {
+    public final class SubJobWorker implements Callable {
         final private MultiJobProject multiJobProject;
         final private BuildListener listener;
         private SubTask subTask;
@@ -410,7 +430,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             this.queue = queue;
         }
 
-        public void run() {
+        public Object call() {
             Result result = null;
             AbstractBuild jobBuild = null;
             try {
@@ -424,6 +444,9 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
 
                 while (retry <= maxRetries && !finish) {
                     retry++;
+                    if (subTask.isShouldTrigger()) {
+                        subTask.GenerateFuture();
+                    }
                     QueueTaskFuture<AbstractBuild> future = (QueueTaskFuture<AbstractBuild>) subTask.future;
                     while (true) {
                         if (subTask.isCancelled()) {
@@ -503,6 +526,8 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                 updateSubBuild(subTask.multiJobBuild, multiJobProject, subTask.phaseConfig);
             }
             queue.add(subTask);
+
+            return Boolean.TRUE;
         }
 
         private List<Pattern> getCompiledPattern() throws FileNotFoundException, InterruptedException {
@@ -1035,6 +1060,42 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
     public void setContinuationCondition(
             ContinuationCondition continuationCondition) {
         this.continuationCondition = continuationCondition;
+    }
+
+    public enum ExecutionType {
+
+        PARALLEL("Running multijob jobs in parallel") {
+            @Override
+            public boolean isParallel() {
+                return true;
+            }
+        },
+        SEQUENTIALLY("Running multiple jobs sequentially") {
+            @Override
+            public boolean isParallel() {
+                return false;
+            }
+        };
+
+        final private String label;
+
+        ExecutionType(String label) {
+            this.label = label;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        abstract public boolean isParallel();
+    }
+
+    public void setExecutionType(ExecutionType executionType) {
+        this.executionType = executionType;
+    }
+
+    public ExecutionType getExecutionType() {
+        return executionType;
     }
 
     public boolean prebuild(Build build, BuildListener listener) {

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -108,6 +108,12 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
      */
     public static final String PERSISTENT_VARS_PREFIX = "RESUMABLE_";
 
+    @Deprecated
+    public MultiJobBuilder(String phaseName, List<PhaseJobsConfig> phaseJobs,
+                           ContinuationCondition continuationCondition) {
+        this(phaseName, phaseJobs, continuationCondition, ExecutionType.PARALLEL);
+    }
+
     @DataBoundConstructor
     public MultiJobBuilder(String phaseName, List<PhaseJobsConfig> phaseJobs,
             ContinuationCondition continuationCondition, ExecutionType executionType) {
@@ -345,6 +351,9 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             return true;
         }
 
+        if (null == executionType) {
+            executionType = ExecutionType.PARALLEL;
+        }
         int poolSize = executionType.isParallel() ? subTasks.size() : 1;
         ExecutorService executor = Executors.newFixedThreadPool(poolSize);
         Set<Result> jobResults = new HashSet<Result>();

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/SubTask.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/SubTask.java
@@ -8,7 +8,6 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Cause.UpstreamCause;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Future;
 
@@ -20,16 +19,19 @@ public final class SubTask {
     final public MultiJobBuild multiJobBuild;
     public Result result;
     private boolean cancel;
+    private boolean isShouldTrigger;
 
-    SubTask(AbstractProject subJob, PhaseJobsConfig phaseConfig, List<Action> actions, MultiJobBuild multiJobBuild, boolean shouldTrigger) {
+    SubTask(AbstractProject subJob, PhaseJobsConfig phaseConfig, List<Action> actions, MultiJobBuild multiJobBuild, boolean isShouldTrigger) {
         this.subJob = subJob;
         this.phaseConfig = phaseConfig;
         this.actions = actions;
         this.multiJobBuild = multiJobBuild;
         this.cancel = false;
-        if (shouldTrigger) {
-            GenerateFuture();
-        }
+        this.isShouldTrigger = isShouldTrigger;
+    }
+
+    public boolean isShouldTrigger() {
+        return isShouldTrigger;
     }
 
     public boolean isCancelled() {

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
@@ -71,6 +71,13 @@
             </table>
         </f:repeatable>
       </f:entry>
+
+      <f:entry title="Job execution type" field="executionType" help="/plugin/jenkins-multijob-plugin/help-executionType">
+        <f:enum field="executionType">
+            ${it.getLabel()}
+        </f:enum>
+      </f:entry>
+
       <f:entry title="Continuation condition to next phase &lt;br&gt; when jobs' statuses are:"
         field="continuationCondition" help="/plugin/jenkins-multijob-plugin/help-continuationCondition.html">
         <f:enum field="continuationCondition">

--- a/src/main/webapp/help-executionType.html
+++ b/src/main/webapp/help-executionType.html
@@ -1,3 +1,4 @@
 <div>
-    Define how to run jobs in a phase: sequentially or parallel. Possibility to run jobs in parallel depends on the available executors.
+    Define how to run jobs in a phase: sequentially or parallel. Possibility to run jobs in parallel depends on the
+    available executors and Jenkins workers numbers.
 </div>

--- a/src/main/webapp/help-executionType.html
+++ b/src/main/webapp/help-executionType.html
@@ -1,0 +1,3 @@
+<div>
+    Define how to run jobs in a phase: sequentially or parallel. Possibility to run jobs in parallel depends on the available executors.
+</div>

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
@@ -55,14 +55,14 @@ public class ConditionalPhaseTest {
         PhaseJobsConfig firstPhase = new PhaseJobsConfig("free", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
         List<PhaseJobsConfig> configTopList = new ArrayList<PhaseJobsConfig>();
         configTopList.add(firstPhase);
-        MultiJobBuilder firstPhaseBuilder = new MultiJobBuilder("FirstPhase", configTopList, ContinuationCondition.SUCCESSFUL);
+        MultiJobBuilder firstPhaseBuilder = new MultiJobBuilder("FirstPhase", configTopList, ContinuationCondition.SUCCESSFUL, MultiJobBuilder.ExecutionType.PARALLEL);
         
         
         // create 'SecondPhase' containing job 'free2'
         PhaseJobsConfig secondPhase = new PhaseJobsConfig("free2", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
         List<PhaseJobsConfig> configTopList2 = new ArrayList<PhaseJobsConfig>();
         configTopList.add(secondPhase);
-        MultiJobBuilder secondPhaseBuilder = new MultiJobBuilder("SecondPhase", configTopList2, ContinuationCondition.SUCCESSFUL);
+        MultiJobBuilder secondPhaseBuilder = new MultiJobBuilder("SecondPhase", configTopList2, ContinuationCondition.SUCCESSFUL, MultiJobBuilder.ExecutionType.PARALLEL);
         
         
         multi.getBuildersList().add(firstPhaseBuilder);


### PR DESCRIPTION
Hi everyone,

I've implemented a feature that allows you to select the type of execution jobs in a phase.
This two options: parallel and sequentially. Running in parallel fully coincides with current execution logic. In the sequential case next job starts after the end of the previous one. The decision to launch the next job is based on phase configuration.

Hope, my request is clear.


<img width="1244" alt="screen shot 2016-02-12 at 17 11 21" src="https://cloud.githubusercontent.com/assets/1222848/13005595/c14fd80e-d1a4-11e5-9132-eec8f42419b4.png">
