### PR TITLE
Support for NOT_BUILT build result

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
@@ -136,6 +136,8 @@ public class MultiJobBuild extends Build<MultiJobProject, MultiJobBuild> {
             Result result = super.run(listener);
             if (isAborted()) {
                 result = Result.ABORTED;
+            } else if (isNotBuilt()) {
+                result = Result.NOT_BUILT;
             } else if (isFailure()) {
                 result = Result.FAILURE;
             } else if (isUnstable()) {
@@ -151,6 +153,10 @@ public class MultiJobBuild extends Build<MultiJobProject, MultiJobBuild> {
         }
 
         private boolean isAborted() {
+            return evaluateResult(Result.NOT_BUILT);
+        }
+
+        private boolean isNotBuilt() {
             return evaluateResult(Result.FAILURE);
         }
 
@@ -194,7 +200,7 @@ public class MultiJobBuild extends Build<MultiJobProject, MultiJobBuild> {
 
         public SubBuild(String parentJobName, int parentBuildNumber,
                 String jobName, int buildNumber, String phaseName,
-                Result result, String icon, String duration, String url, 
+                Result result, String icon, String duration, String url,
                 AbstractBuild<?, ?> build) {
             this.parentJobName = parentJobName;
             this.parentBuildNumber = parentBuildNumber;
@@ -273,7 +279,7 @@ public class MultiJobBuild extends Build<MultiJobProject, MultiJobBuild> {
         public String getJobName() {
             return jobName;
         }
-        
+
         @Exported
         public int getBuildNumber() {
             return buildNumber;


### PR DESCRIPTION
This change was driven by a need on my team to surface NOT_BUILT as the actual 
build result in order to affect how the Jenkins Gerrit trigger plugin votes on 
a code review. When NOT_BUILT is passed back, no negative or positive action is 
taken on a code review. How we use this is to examine certain aspects of what was 
changed in a review and how it relates to the artifacts we need to generate.  
If certain conditions are met, then we set a job's result to NOT_BUILT to
indicate that no build action is required.

I realized this may be too specialized for general use, but I wanted to offer it up regardless.