### PR TITLE
Verify env variables are identical on resume

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobProject.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobProject.java
@@ -23,6 +23,8 @@ import hudson.scm.PollingResult.*;
 import com.tikal.jenkins.plugins.multijob.views.MultiJobView;
 
 import net.sf.json.JSONObject;
+
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -30,6 +32,7 @@ public class MultiJobProject extends Project<MultiJobProject, MultiJobBuild>
 		implements TopLevelItem {
 
         private volatile boolean pollSubjobs = false;
+        private volatile String resumeEnvVars = null;
 
 	@SuppressWarnings("rawtypes")
 	private MultiJobProject(ItemGroup parent, String name) {
@@ -121,6 +124,18 @@ public class MultiJobProject extends Project<MultiJobProject, MultiJobBuild>
             pollSubjobs = poll;
         }
 
+        public String getResumeEnvVars() {
+			return resumeEnvVars;
+		}
+
+        public void setResumeEnvVars(String resumeEnvVars) {
+			this.resumeEnvVars = resumeEnvVars;
+		}
+
+        public boolean getCheckResumeEnvVars() {
+        	return !StringUtils.isBlank(resumeEnvVars);
+        }
+
     @Override
     protected void submit(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException, FormException {
         super.submit(req, rsp);
@@ -132,6 +147,15 @@ public class MultiJobProject extends Project<MultiJobProject, MultiJobBuild>
             if (json.has(k)) {
                 setPollSubjobs(json.getBoolean(k));
             }
+            String resumeEnvVars = null;
+            k = "resumeEnvVars";
+            if (json.has(k)) {
+            	json = json.getJSONObject(k);
+                if (json.has(k)) {
+                	resumeEnvVars = json.getString(k);
+                }
+            }
+            setResumeEnvVars(resumeEnvVars);
         }
     }
 }

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobProject/configure-entries.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobProject/configure-entries.jelly
@@ -28,6 +28,11 @@ THE SOFTWARE.
     <f:entry title="Poll subjobs in addition to multijob when polling" field="pollSubjobs" help="/plugin/jenkins-multijob-plugin/help-pollsubjobs.html">
       <f:checkbox/>
     </f:entry>
+    <f:optionalBlock name="resumeEnvVars" title="Resume build with identical environment variables" checked="${it.checkResumeEnvVars}">
+      <f:entry title="Environment Variables" help="/plugin/jenkins-multijob-plugin/help-resumesamevars.html">
+        <f:textbox field="resumeEnvVars"/>
+      </f:entry>
+    </f:optionalBlock>
   </f:section>
 
   <p:config-trigger/>

--- a/src/main/webapp/help-resumesamevars.html
+++ b/src/main/webapp/help-resumesamevars.html
@@ -1,0 +1,6 @@
+<div>
+    Will perform a check before resuming a build to ensure all the listed environment variables are identical between the resumed build and the current build.<br/>
+    e.g.: This could be used to ensure we are not resuming a build from an older SCM revision (GIT_COMMIT, SVN_REVISION, etc.)<br/>
+    If the variables don't match, a full build will be triggered instead.<br/>
+    You can define multiple variables using comma as a separator.<br/>
+</div>


### PR DESCRIPTION
Hi,

I've added a new option to the configuration page to verify that environment variables are identical when resuming a build.

This can be used to validate the build we are resuming from is in a consistent state with the workspace. e.g.: GIT_COMMIT

When the variable valuess are different, a full build is triggered instead.

This property is optional, therefore the current behavior is maintained.


Cheers,