### PR TITLE
just store the build number rather than the build object on the action

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -838,11 +838,11 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
     }
 
     private class MultiJobAction implements Action, QueueAction {
-        public AbstractBuild build;
+        public int buildNumber;
         public int index;
 
         public MultiJobAction(AbstractBuild build, int index) {
-            this.build = build;
+            this.buildNumber = build.getNumber();
             this.index = index;
         }
 
@@ -853,7 +853,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                 if (action.index != index) {
                     matches = false;
                 }
-                if (action.build.getNumber() != build.getNumber()) {
+                if (action.buildNumber != buildNumber) {
                     matches = false;
                 }
             }


### PR DESCRIPTION
storing the build object means that it needs to be serialized when
actions are serialized, and this can cause spurious failures
(CuncurrentModificationException) if something else is trying to modify
the build object's subBuildMap at the same time.