### PR TITLE
Fix backwards compatibility bug with old build data

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -899,8 +899,20 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
     }
 
     private class MultiJobAction implements Action, QueueAction {
+        protected transient AbstractBuild build;
         public int buildNumber;
         public int index;
+
+        /**
+         * Maintain backwards compatibility with previous versions of this class.
+         * See https://wiki.jenkins-ci.org/display/JENKINS/Hint+on+retaining+backward+compatibility
+         */
+        protected Object readResolve() {
+            if (build != null) {
+                buildNumber = build.getNumber();
+            }
+            return this;
+        }
 
         public MultiJobAction(AbstractBuild build, int index) {
             this.buildNumber = build.getNumber();

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -899,20 +899,16 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
     }
 
     private class MultiJobAction implements Action, QueueAction {
-        protected transient AbstractBuild build;
         public int buildNumber;
         public int index;
 
         /**
+         * @deprecated
          * Maintain backwards compatibility with previous versions of this class.
          * See https://wiki.jenkins-ci.org/display/JENKINS/Hint+on+retaining+backward+compatibility
          */
-        protected Object readResolve() {
-            if (build != null) {
-                buildNumber = build.getNumber();
-            }
-            return this;
-        }
+        @Deprecated
+        private transient AbstractBuild build;
 
         public MultiJobAction(AbstractBuild build, int index) {
             this.buildNumber = build.getNumber();
@@ -932,6 +928,13 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             }
 
             return !matches;
+        }
+
+        protected Object readResolve() {
+            if (build != null) {
+                buildNumber = build.getNumber();
+            }
+            return this;
         }
 
         public String getIconFileName() {


### PR DESCRIPTION
For heavy users of this plugin, upgrading the plugin exposes users to
an unhandled backwards incompatibility in the data persistence format.

In our case, it caused the OldDataMonitor object to become flooded with
error messages from trying to load old jobs, to the point of slowly but
surely filling up as much heap as we could throw at Jenkins due to the
large number of builds we have using this plugin.

This change implements the readResolve method used by the XStream
persistence layer to convert old build data to the new version, as
described in the Jenkins documentation. See the linked Jenkins help page
in code comments for more details.

The original backwards incompatibility was found here: https://github.com/jenkinsci/tikal-multijob-plugin/pull/97 after finding a very large number of incidences of the following message in our OldDataMonitor object:

```
MissingFieldException: No field 'build' found in class 'com.tikal.jenkins.plugins.multijob.MultiJobBuilder$MultiJobAction', ConversionException: Invalid reference
```