### PR TITLE
[JENKINS-49328] Fix the non-transient nested reference

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
@@ -196,7 +196,7 @@ public class MultiJobBuild extends Build<MultiJobProject, MultiJobBuild> {
         private final String url;
         private final boolean retry;
         private final boolean aborted;
-        private final AbstractBuild<?, ?> build;
+        private transient final AbstractBuild<?, ?> build;
 
         public SubBuild(String parentJobName, int parentBuildNumber,
                 String jobName, int buildNumber, String phaseName,


### PR DESCRIPTION
@reviewbybees 

### Description

`MultiJobBuild$SubBuild` references a model object as non-transient resulting in to replaceIfNotAtTopLevel warning. See [JENKINS-45892](https://issues.jenkins-ci.org/browse/JENKINS-45892).

See [JENKINS-49328](https://issues.jenkins-ci.org/browse/JENKINS-49328)