### PR TITLE
Adding pretend success option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
 			<artifactId>parameterized-trigger</artifactId>
 			<version>2.25</version>
 		</dependency>
-                
-                
+
+
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
@@ -50,6 +50,7 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 	private boolean aggregatedTestResults;
 	private boolean exposedSCM;
 	private boolean disableJob;
+	private boolean pretendSuccess;
 	private String parsingRulesPath;
 	private int maxRetries;
 	private boolean enableRetryStrategy;
@@ -133,6 +134,14 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 		this.disableJob = disableJob;
 	}
 
+	public boolean isPretendSuccess() {
+		return pretendSuccess;
+	}
+
+	public void setPretendSuccess(boolean pretendSuccess) {
+		this.pretendSuccess = pretendSuccess;
+	}
+
 	public KillPhaseOnJobResultCondition getKillPhaseOnJobResultCondition() {
 		return killPhaseOnJobResultCondition;
 	}
@@ -193,12 +202,12 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 	public PhaseJobsConfig(String jobName, String jobProperties,
 			boolean currParams, List<AbstractBuildParameters> configs,
 			KillPhaseOnJobResultCondition killPhaseOnJobResultCondition,
-			boolean disableJob, boolean enableRetryStrategy,
+			boolean disableJob, boolean pretendSuccess, boolean enableRetryStrategy,
 			String parsingRulesPath, int maxRetries, boolean enableCondition,
 			boolean abortAllJob, String condition, boolean buildOnlyIfSCMChanges,
                         boolean applyConditionOnlyIfNoSCMChanges) {
             this(jobName, jobProperties, currParams, configs, killPhaseOnJobResultCondition,
-                    disableJob, enableRetryStrategy, parsingRulesPath, maxRetries, enableCondition,
+                    disableJob, pretendSuccess, enableRetryStrategy, parsingRulesPath, maxRetries, enableCondition,
                     abortAllJob, condition, buildOnlyIfSCMChanges, applyConditionOnlyIfNoSCMChanges, false);
         }
         
@@ -206,7 +215,7 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 	public PhaseJobsConfig(String jobName, String jobProperties,
 			boolean currParams, List<AbstractBuildParameters> configs,
 			KillPhaseOnJobResultCondition killPhaseOnJobResultCondition,
-			boolean disableJob, boolean enableRetryStrategy,
+			boolean disableJob, boolean pretendSuccess, boolean enableRetryStrategy,
 			String parsingRulesPath, int maxRetries, boolean enableCondition,
 			boolean abortAllJob, String condition, boolean buildOnlyIfSCMChanges,
                         boolean applyConditionOnlyIfNoSCMChanges, boolean aggregatedTestResults) {
@@ -215,6 +224,7 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 		this.currParams = currParams;
 		this.killPhaseOnJobResultCondition = killPhaseOnJobResultCondition;
 		this.disableJob = disableJob;
+		this.pretendSuccess = pretendSuccess;
 		this.configs = Util.fixNull(configs);
 		this.enableRetryStrategy = enableRetryStrategy;
 		this.maxRetries = maxRetries;

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
@@ -24,6 +24,9 @@
                 <f:entry title="Disable" field="disableJob">
                     <f:checkbox name="disableJob" checked="${instance.disableJob}" default="false"/>
                 </f:entry>
+                <f:entry title="Pretend Success" field="pretendSuccess" help="/plugin/jenkins-multijob-plugin/help-pretendSuccess.html">
+                    <f:checkbox name="pretendSuccess" checked="${instance.pretendSuccess}" default="false"/>
+                </f:entry>
                 <f:entry title="Abort all other job" field="abortAllJob" help="/plugin/jenkins-multijob-plugin/help-abort.html">
                     <f:checkbox name="abortAllJob" checked="${instance.abortAllJob}" default="true"/>
                 </f:entry>

--- a/src/main/webapp/help-pretendSuccess.html
+++ b/src/main/webapp/help-pretendSuccess.html
@@ -1,0 +1,4 @@
+<div>
+    Ignore the result of this job and pretend that sucess was returned.<br/>
+    Great for adding out a new phase job in production without having it break functionality
+</div>

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
@@ -54,14 +54,14 @@ public class ConditionalPhaseTest {
         final MultiJobProject multi = j.jenkins.createProject(MultiJobProject.class, "MultiTop");
 
         // create 'FirstPhase' containing job 'free'
-        PhaseJobsConfig firstPhase = new PhaseJobsConfig("free", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
+        PhaseJobsConfig firstPhase = new PhaseJobsConfig("free", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, false, "", 0, false, false, "",false, false);
         List<PhaseJobsConfig> configTopList = new ArrayList<PhaseJobsConfig>();
         configTopList.add(firstPhase);
         MultiJobBuilder firstPhaseBuilder = new MultiJobBuilder("FirstPhase", configTopList, ContinuationCondition.SUCCESSFUL, MultiJobBuilder.ExecutionType.PARALLEL);
         
         
         // create 'SecondPhase' containing job 'free2'
-        PhaseJobsConfig secondPhase = new PhaseJobsConfig("free2", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
+        PhaseJobsConfig secondPhase = new PhaseJobsConfig("free2", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, false, "", 0, false, false, "",false, false);
         List<PhaseJobsConfig> configTopList2 = new ArrayList<PhaseJobsConfig>();
         configTopList.add(secondPhase);
         MultiJobBuilder secondPhaseBuilder = new MultiJobBuilder("SecondPhase", configTopList2, ContinuationCondition.SUCCESSFUL, MultiJobBuilder.ExecutionType.PARALLEL);

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/PhaseJobsConfigTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/PhaseJobsConfigTest.java
@@ -81,7 +81,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(null);
 		MultiJobBuild mjb =createTriggeringBuild(null);
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "" , true, false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, false, "", 0, false, false, "" , true, false);
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 		// check single ParametersAction created
@@ -93,7 +93,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(null);
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, false, "", 0, false, false, "",false, false);
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
 		// check single ParametersAction created
@@ -113,7 +113,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(createParametersAction(CURRENT_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "" , false, false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, false, "", 0, false, false, "" , false, false);
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
@@ -136,7 +136,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(createParametersAction(OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, false, "", 0, false, false, "",false, false);
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
@@ -158,7 +158,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		AbstractProject projectB = createTriggeredProject(DEFAULT_KEY_VALUES);
 		MultiJobBuild mjb = createTriggeringBuild(createParametersAction(OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, null, KillPhaseOnJobResultCondition.NEVER, false, false, false, "", 0, false, false, "",false, false);
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, false);
 
 		// check single ParametersAction created
@@ -181,7 +181,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		configs.add(new TestParametersConfig());
 		configs.add(new TestParametersConfig(OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, false, "", 0, false, false, "",false, false);
 
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
@@ -210,7 +210,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		configs.add(new TestParametersConfig());
 		configs.add(new TestParametersConfig(CONFIG_OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, false, "", 0, false, false, "",false, false);
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, true);
 
@@ -239,7 +239,7 @@ public class PhaseJobsConfigTest extends HudsonTestCase{
 		configs.add(new TestParametersConfig());
 		configs.add(new TestParametersConfig(CONFIG_OVERRIDES_KEY_VALUES));
 
-		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
+		PhaseJobsConfig pjc = new PhaseJobsConfig("dummy", "", true, configs, KillPhaseOnJobResultCondition.NEVER, false, false, false, "", 0, false, false, "",false, false);
 
 
 		List<Action> actions = pjc.getActions(mjb, TaskListener.NULL, projectB, false);


### PR DESCRIPTION
Inspired by this: https://github.com/jenkinsci/tikal-multijob-plugin/issues/121 and a use case that I needed (I can't block the builds with an unstable job).

Basically will still run the job as normal, but the result will be passed as success.
The job and phase will still show the actual status but the overall job will be success.

The option is off by default, so the plugin will continue to work for everyone as normal.

This is my first time contributing, so let me know if I need to make any changes.
Thanks