### PR TITLE
Fixing a bug that was retrying twice the number specified for maxretries field.

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -537,7 +537,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                                     listener.getLogger().println("Known failure detected, retrying this build. Try " + retry + " of " + maxRetries + ".");
                                     updateSubBuild(subTask.multiJobBuild, multiJobProject, jobBuild, result, true);
 
-                                    subTask.generateFuture();
+                                    //subTask.generateFuture();
                                 } else {
                                     listener.getLogger().println("Known failure detected, max retries (" + maxRetries + ") exceeded.");
                                     updateSubBuild(subTask.multiJobBuild, multiJobProject, jobBuild, result);


### PR DESCRIPTION
Fixing a bug that was retrying twice the number specified for maxretries field. _E.g. if I specify "1" in maxretry field, it triggers the phase job twice. This was a big headache for us as our job runs for 90 min and if it fails the retry option trigger's it twice and it accounts only the result of 2nd job, so the multijob waits for approx 180 min to get result of retry job._ 

subTask.generateFuture() is executed twice for every retry attempt and hence twice the number of jobs get triggered. I believe subTask.isShouldTrigger() never becomes false hence subTask.generateFuture() runs twice.

Change-Id: I123b1d16b947305b8dd96da6d1ca6d8a5ef7762e