### PR TITLE
Setting the default to false for aborting all the child jobs

### DIFF
--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
@@ -29,7 +29,7 @@
                     <f:checkbox name="disableJob" checked="${instance.disableJob}" default="false"/>
                 </f:entry>
                 <f:entry title="Abort all other job" field="abortAllJob" help="/plugin/jenkins-multijob-plugin/help-abort.html">
-                    <f:checkbox name="abortAllJob" checked="${instance.abortAllJob}" default="true"/>
+                    <f:checkbox name="abortAllJob" checked="${instance.abortAllJob}" default="false"/>
                 </f:entry>
                 <f:entry title="Aggregated Test Results" field="aggregatedTestResults">
                     <f:checkbox name="aggregatedTestResults" checked="${instance.aggregatedTestResults}" default="false"/>


### PR DESCRIPTION
Currently "Abort all the child jobs" is set to true by
default. While there could be arguments for both scenario's,
I am not necessarily sure if its required to have the feature
be set to true, by default.

Scenario:
-> We have a parent job which we start for a release and
that spins off all the child test jobs in parallel. Now, if
one child job fails we don't want all the other child jobs
to abort by default.
-> Most of our Jenkins users/job creators are beginners, so
they dont really know that this feature can have catastrophic
effect. Thus, requesting this change.

What would be better to have is to allow this via configuration
just like "Parsing Rules", but I am not 100% sure how to make
the change and how to test it after that. So requesting
this for now.