### PR TITLE
Calculate a sub-job's quiet time based on a Groovy expression parameter.

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/QuietPeriodCalculator.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/QuietPeriodCalculator.java
@@ -1,0 +1,54 @@
+package com.tikal.jenkins.plugins.multijob;
+
+import groovy.util.Eval;
+import hudson.model.BuildListener;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+class QuietPeriodCalculator {
+
+	private final static Logger LOG = Logger.getLogger(QuietPeriodCalculator.class.getName());
+	private final BuildListener listener;
+	private final String displayName;
+
+	QuietPeriodCalculator() {
+		this(null, null);
+	}
+
+	QuietPeriodCalculator(final BuildListener listener, final String displayNameOrNull) {
+		this.listener = listener;
+		this.displayName = displayNameOrNull == null ? "" : displayNameOrNull + ": ";
+	}
+
+	int calculate(String quietPeriodGroovy, int index) {
+
+		if (quietPeriodGroovy == null) {
+			return 0;
+		}
+		try {
+			return calculateOrThrow(quietPeriodGroovy, index);
+		} catch (Throwable t) {
+			final String message =
+					"Error calculating quiet time for index " + index + " and quietPeriodGroovy [" + quietPeriodGroovy +
+							"]: " + t.getMessage() + "; returning 0";
+			LOG.log(Level.WARNING, message, t);
+			log(message);
+			return 0;
+		}
+
+	}
+
+	int calculateOrThrow(final String quietPeriodGroovy, final int index) {
+
+		final Integer quietPeriod = (Integer) Eval.me("index", index, quietPeriodGroovy);
+		log(displayName + "Quiet period groovy=[" + quietPeriodGroovy + "], index=" + index + " -> quietPeriodGroovy=" + quietPeriod);
+		return quietPeriod;
+	}
+
+	private void log(final String s) {
+		if (listener != null) {
+			listener.getLogger().println(s);
+		}
+	}
+}

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/QuietPeriodCalculator.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/QuietPeriodCalculator.java
@@ -6,13 +6,13 @@ import hudson.model.BuildListener;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-class QuietPeriodCalculator {
+public class QuietPeriodCalculator {
 
 	private final static Logger LOG = Logger.getLogger(QuietPeriodCalculator.class.getName());
 	private final BuildListener listener;
 	private final String displayName;
 
-	QuietPeriodCalculator() {
+	public QuietPeriodCalculator() {
 		this(null, null);
 	}
 
@@ -21,11 +21,16 @@ class QuietPeriodCalculator {
 		this.displayName = displayNameOrNull == null ? "" : displayNameOrNull + ": ";
 	}
 
-	int calculate(String quietPeriodGroovy, int index) {
+	public int calculate(String quietPeriodGroovy, int index) {
 
 		if (quietPeriodGroovy == null) {
 			return 0;
 		}
+
+		if (index < 0) {
+			throw new IllegalArgumentException("positive index expected, got " + index);
+		}
+
 		try {
 			return calculateOrThrow(quietPeriodGroovy, index);
 		} catch (Throwable t) {
@@ -39,7 +44,7 @@ class QuietPeriodCalculator {
 
 	}
 
-	int calculateOrThrow(final String quietPeriodGroovy, final int index) {
+	public int calculateOrThrow(final String quietPeriodGroovy, final int index) {
 
 		final Integer quietPeriod = (Integer) Eval.me("index", index, quietPeriodGroovy);
 		log(displayName + "Quiet period groovy=[" + quietPeriodGroovy + "], index=" + index + " -> quietPeriodGroovy=" + quietPeriod);

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/QuietPeriodCalculator.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/QuietPeriodCalculator.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 public class QuietPeriodCalculator {
 
 	private final static Logger LOG = Logger.getLogger(QuietPeriodCalculator.class.getName());
+	private static final String INDEX = "index";
 	private final BuildListener listener;
 	private final String displayName;
 
@@ -27,9 +28,7 @@ public class QuietPeriodCalculator {
 			return 0;
 		}
 
-		if (index < 0) {
-			throw new IllegalArgumentException("positive index expected, got " + index);
-		}
+		assertPositiveIndex(index);
 
 		try {
 			return calculateOrThrow(quietPeriodGroovy, index);
@@ -46,9 +45,17 @@ public class QuietPeriodCalculator {
 
 	public int calculateOrThrow(final String quietPeriodGroovy, final int index) {
 
-		final Integer quietPeriod = (Integer) Eval.me("index", index, quietPeriodGroovy);
+		assertPositiveIndex(index);
+
+		final Integer quietPeriod = (Integer) Eval.me(INDEX, index, quietPeriodGroovy);
 		log(displayName + "Quiet period groovy=[" + quietPeriodGroovy + "], index=" + index + " -> quietPeriodGroovy=" + quietPeriod);
 		return quietPeriod;
+	}
+
+	private static void assertPositiveIndex(final int index) {
+		if (index < 0) {
+			throw new IllegalArgumentException("positive index expected, got " + index);
+		}
 	}
 
 	private void log(final String s) {

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/views/PhaseWrapper.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/views/PhaseWrapper.java
@@ -62,7 +62,7 @@ public class PhaseWrapper extends AbstractWrapper {
 
             Run build = (Run) project
                     .getBuildByNumber(buildState.getLastBuildNumber());
-            if (build == null)
+            if (build == null || build.getResult() == null)
                 continue;
 
             if (worseBuild == null) {

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
@@ -11,7 +11,6 @@
                      help="/plugin/jenkins-multijob-plugin/help-jobName.html">
                 <f:textbox />
             </f:entry>
-        
             <f:advanced>
                 <f:entry title="Job alias" field="jobAlias"
                          help="/plugin/jenkins-multijob-plugin/help-jobAlias.html">
@@ -84,6 +83,10 @@
         <f:enum field="executionType">
             ${it.getLabel()}
         </f:enum>
+      </f:entry>
+
+      <f:entry title="Quiet period calculator" field="quietPeriodGroovy" help="/plugin/jenkins-multijob-plugin/help-quiet-period-calculator.html">
+        <f:textbox name="quietPeriodGroovy" default="index &lt; 5 ? 0 : 2 * 60" />
       </f:entry>
 
       <f:entry title="Continuation condition to next phase &lt;br&gt; when jobs' statuses are:"

--- a/src/main/webapp/help-quiet-period-calculator.html
+++ b/src/main/webapp/help-quiet-period-calculator.html
@@ -1,0 +1,15 @@
+<div>
+    <p>
+        Enter a Groovy snipped that calculates a quiet period for a sub-job by it's index. The index is available
+        as a variable named <i>index</i>. The resulting number is set as the quiet period in seconds.
+    </p>
+    <p>
+        Examples:
+    <ul>
+        <li><code>0</code>: no quiet period for all sub-jobs</li>
+        <li><code>index &lt; 5 ? 0 : 2 * 60</code>: start 4 jobs immediately, the other ones with a quiet time of 2
+            minutes.
+        </li>
+    </ul>
+    </p>
+</div>

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/ConditionalPhaseTest.java
@@ -43,30 +43,30 @@ public class ConditionalPhaseTest {
         // MultiTop
         //  |_ FirstPhase
         //      |_ free
-        //  |_ [?] SecondPhase 
+        //  |_ [?] SecondPhase
         //          |_ free2
 
         final FreeStyleProject free = j.jenkins.createProject(FreeStyleProject.class, "Free");
         free.getBuildersList().add(new Shell("echo hello"));
         final FreeStyleProject free2 = j.jenkins.createProject(FreeStyleProject.class, "Free2");
         free2.getBuildersList().add(new Shell("echo hello2"));
-        
+
         final MultiJobProject multi = j.jenkins.createProject(MultiJobProject.class, "MultiTop");
 
         // create 'FirstPhase' containing job 'free'
         PhaseJobsConfig firstPhase = new PhaseJobsConfig("free", "freeAlias", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
         List<PhaseJobsConfig> configTopList = new ArrayList<PhaseJobsConfig>();
         configTopList.add(firstPhase);
-        MultiJobBuilder firstPhaseBuilder = new MultiJobBuilder("FirstPhase", configTopList, ContinuationCondition.SUCCESSFUL, MultiJobBuilder.ExecutionType.PARALLEL);
-        
-        
+        MultiJobBuilder firstPhaseBuilder = new MultiJobBuilder("FirstPhase", configTopList, ContinuationCondition.SUCCESSFUL, MultiJobBuilder.ExecutionType.PARALLEL, null);
+
+
         // create 'SecondPhase' containing job 'free2'
         PhaseJobsConfig secondPhase = new PhaseJobsConfig("free2", "free2Alias", null, true, null, KillPhaseOnJobResultCondition.NEVER, false, false, "", 0, false, false, "",false, false);
         List<PhaseJobsConfig> configTopList2 = new ArrayList<PhaseJobsConfig>();
         configTopList.add(secondPhase);
-        MultiJobBuilder secondPhaseBuilder = new MultiJobBuilder("SecondPhase", configTopList2, ContinuationCondition.SUCCESSFUL, MultiJobBuilder.ExecutionType.PARALLEL);
-        
-        
+        MultiJobBuilder secondPhaseBuilder = new MultiJobBuilder("SecondPhase", configTopList2, ContinuationCondition.SUCCESSFUL, MultiJobBuilder.ExecutionType.PARALLEL, null);
+
+
         multi.getBuildersList().add(firstPhaseBuilder);
         multi.getBuildersList().add(new Shell("echo dude"));
         // wrap second phase in condition
@@ -91,7 +91,7 @@ public class ConditionalPhaseTest {
                 }
             }
         }
-       
+
         Assert.assertEquals("there should be two phases and three projects", 5, multi.getView().getRootItem(multi).size());
         Assert.assertEquals("there should be two phases", 2, numberOfPhases);
         Assert.assertEquals("there should be three projects", 3, numberOfProjects);

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/QuietPeriodCalculatorTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/QuietPeriodCalculatorTest.java
@@ -1,0 +1,50 @@
+package com.tikal.jenkins.plugins.multijob.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.tikal.jenkins.plugins.multijob.QuietPeriodCalculator;
+
+public class QuietPeriodCalculatorTest {
+	private static final String CALC = "index < 5 ? 0 : 2 * 60";
+	private final QuietPeriodCalculator calculator = new QuietPeriodCalculator();
+
+	@Test
+	public void testCalculate_StaticScript() {
+		assertEquals(1, calculator.calculate("1", 1));
+		assertEquals(2, calculator.calculate("2", 1));
+	}
+
+	@Test
+	public void testCalculate_CalculatingScript() {
+		assertEquals(0, calculator.calculate(CALC, 1));
+		assertEquals(120, calculator.calculate(CALC, 5));
+	}
+
+	@Test
+	public void testCalculate_ScriptErrorReturnsResult() {
+		assertEquals(0, calculator.calculate("invalid script", 1));
+	}
+
+	@Test
+	public void testCalculateOrThrow_ScriptErrorThrows() {
+		try {
+			calculator.calculateOrThrow("invalid script", 1);
+			fail("Exception expected");
+		} catch (RuntimeException re) {
+			// expected
+		}
+	}
+
+	@Test
+	public void testCalculate_NegativeIndexThrows() {
+		try {
+			calculator.calculateOrThrow(CALC, -1);
+			fail("IllegalArgumentException expected");
+		} catch (IllegalArgumentException iae) {
+			// expected
+		}
+	}
+}

--- a/src/test/java/com/tikal/jenkins/plugins/multijob/test/QuietPeriodCalculatorTest.java
+++ b/src/test/java/com/tikal/jenkins/plugins/multijob/test/QuietPeriodCalculatorTest.java
@@ -41,6 +41,15 @@ public class QuietPeriodCalculatorTest {
 	@Test
 	public void testCalculate_NegativeIndexThrows() {
 		try {
+			calculator.calculate(CALC, -1);
+			fail("IllegalArgumentException expected");
+		} catch (IllegalArgumentException iae) {
+			// expected
+		}
+	}
+	@Test
+	public void testCalculateOrThrow_NegativeIndexThrows() {
+		try {
 			calculator.calculateOrThrow(CALC, -1);
 			fail("IllegalArgumentException expected");
 		} catch (IllegalArgumentException iae) {


### PR DESCRIPTION
To avoid massive load on out database server this configuration
makes it possible to delay the execution of all or some sub-jobs
based on the sub-job index.

Should fix #158 as well.