### PR TITLE
fix multijob build selector for copy-artifacts

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuildSelector.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuildSelector.java
@@ -41,6 +41,12 @@ public class MultiJobBuildSelector extends BuildSelector {
             // Matrix run is triggered by its parent project, so check causes of parent build:
             for (Cause cause : parent instanceof MatrixRun
                     ? ((MatrixRun)parent).getParentBuild().getCauses() : parent.getCauses()) {
+                if (cause instanceof UpstreamCause) {
+                    // We need only builds with upstream cause
+                } else {
+                    LOGGER.warning(String.format("'%s' Has no upstream build.", parent.getFullDisplayName()));
+                    break;
+                }
                 UpstreamCause upstreamCause = (UpstreamCause)cause;
                 Job upstreamJob = Jenkins.getInstance().getItemByFullName(upstreamCause.getUpstreamProject(), Job.class);
                 Run upstreamRun = upstreamJob.getBuildByNumber(upstreamCause.getUpstreamBuild());
@@ -48,6 +54,8 @@ public class MultiJobBuildSelector extends BuildSelector {
                 if (upstreamRun != null && upstreamRun instanceof MultiJobBuild) {
                     multiJobBuild = (MultiJobBuild)upstreamRun;
                 }
+                // We need only first cause, don't care about the previous
+                break;
             }
         }
         if (multiJobBuild == null) {


### PR DESCRIPTION
This fix address the issue when subjob of multijob build
tries to use copy-artifact with "Which build" set to:
"Build triggered by current MultiJob build"

Job interrupts with following stacktrace:
```
ERROR: Build step failed with exception
java.lang.ClassCastException: hudson.model.Cause$UserIdCause cannot be cast to hudson.model.Cause$UpstreamCause
	at com.tikal.jenkins.plugins.multijob.MultiJobBuildSelector.getBuild(MultiJobBuildSelector.java:44)
	at hudson.plugins.copyartifact.CopyArtifact.perform(CopyArtifact.java:420)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:79)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:741)
	at hudson.model.Build$BuildExecution.build(Build.java:206)
	at hudson.model.Build$BuildExecution.doRun(Build.java:163)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
	at hudson.model.Run.execute(Run.java:1818)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Build step 'Copy artifacts from another project' marked build as failure
```

Fixes: https://github.com/jenkinsci/tikal-multijob-plugin/issues/190

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>