### PR TITLE
fixes groovy quiet period configuration field

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -79,6 +79,7 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
     private List<PhaseJobsConfig> phaseJobs;
     private ContinuationCondition continuationCondition = ContinuationCondition.SUCCESSFUL;
     private ExecutionType executionType;
+
     private String quietPeriodGroovy = DEFAULT_QUIET_PERIOD_GROOVY;
 
     final static Pattern PATTERN = Pattern.compile("(\\$\\{.+?\\})", Pattern.CASE_INSENSITIVE);
@@ -1223,6 +1224,10 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
     public ExecutionType getExecutionType() {
         return executionType;
     }
+    public String getQuietPeriodGroovy() {
+        return quietPeriodGroovy;
+    }
+
 
     public boolean prebuild(Build build, BuildListener listener) {
         boolean resume = false;

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuilder/config.jelly
@@ -86,7 +86,7 @@
       </f:entry>
 
       <f:entry title="Quiet period calculator" field="quietPeriodGroovy" help="/plugin/jenkins-multijob-plugin/help-quiet-period-calculator.html">
-        <f:textbox name="quietPeriodGroovy" default="index &lt; 5 ? 0 : 2 * 60" />
+        <f:textbox />
       </f:entry>
 
       <f:entry title="Continuation condition to next phase &lt;br&gt; when jobs' statuses are:"


### PR DESCRIPTION
my previous contribution had an error: the field's value did always contain the default value 
provided in config.jelly. 
This change fixes groovy quiet period configuration in the field field.

It would be great if the plugin could be released soon.

Cheers,
Marc
