### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuild/table.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuild/table.jelly
@@ -62,7 +62,7 @@
 				</td>
 				<td class="no-wrap" align="center">
 					<a href="${rootURL}/${builder.url}console">
-						<img src="${imagesURL}/24x24/terminal.png" alt="Console Output" />
+						<l:icon class="icon-terminal icon-md" alt="Console Output" />
 					</a>
 				</td>
 			</tr>

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/views/ConsoleColumn/column.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/views/ConsoleColumn/column.jelly
@@ -7,7 +7,7 @@
 		<j:choose>
 			<j:when test="${lBuild!=null}">
 				<a href="${job.absoluteUrl}${job.getBuildNumber()}/console">
-					<l:icon class="icon-terminal icon-${subIconSize}" title="${%Console output}"
+					<l:icon class="icon-terminal icon-${subIconSizeClass}" title="${%Console output}"
 						alt="${%Console output}" border="0" />
 				</a>
 			</j:when>

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/views/ConsoleColumn/column.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/views/ConsoleColumn/column.jelly
@@ -7,7 +7,7 @@
 		<j:choose>
 			<j:when test="${lBuild!=null}">
 				<a href="${job.absoluteUrl}${job.getBuildNumber()}/console">
-					<img src="${imagesURL}/${subIconSize}/terminal.gif" title="${%Console output}"
+					<l:icon class="icon-terminal icon-${subIconSize}" title="${%Console output}"
 						alt="${%Console output}" border="0" />
 				</a>
 			</j:when>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @yorammi 
Thanks in advance!