### PR TITLE
Upgrade parent, plugin dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,2 @@
-buildPlugin jenkinsVersions: [null, '2.89.2'],
-  platforms: ['linux'] // TODO fix e.g. testConditionalPhase
+buildPlugin()
+

--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,6 @@
 	<properties>
 		<findbugs.failOnError>false</findbugs.failOnError>
                 <jenkins.version>2.319.3</jenkins.version>
-		<java.level>8</java.level>
 		<changelist>999999-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -286,7 +286,7 @@
 
 	<properties>
 		<findbugs.failOnError>false</findbugs.failOnError>
-                <jenkins.version>2.319.3</jenkins.version>
+                <jenkins.version>2.319.1</jenkins.version>
 		<changelist>999999-SNAPSHOT</changelist>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,17 +76,13 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>
-			<!--
-				1.25 and earlier are vulnerable
-				https://www.jenkins.io/security/advisory/2018-09-25/
-			-->
-			<version>1.26</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>envinject</artifactId>
-			<version>1.90</version>
+			<!-- 1.90 and earlier vulnerable: https://www.jenkins.io/security/advisory/2018-02-26/ -->
+			<version>1.91</version>
 		</dependency>
 
 		<dependency>
@@ -98,24 +94,23 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>token-macro</artifactId>
-			<version>1.10</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>mailer</artifactId>
-			<version>1.32.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>
 			<artifactId>maven-plugin</artifactId>
-			<!--
-				3.3 and earlier are vulnerable
-				https://www.jenkins.io/security/advisory/2019-07-31/
-			-->
+			<!-- 3.3 and earlier vulnerable: https://www.jenkins.io/security/advisory/2019-07-31/ -->
 			<version>3.4</version>
 			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
 				<exclusion>
 					<groupId>org.apache.httpcomponents</groupId>
 					<artifactId>httpclient</artifactId>
@@ -138,7 +133,8 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>copyartifact</artifactId>
-			<version>1.31</version>
+			<!-- 1.43.1 and earlier vulnerable: https://www.jenkins.io/security/advisory/2020-05-06/ -->
+			<version>1.44</version>
 			<optional>true</optional>
 		</dependency>
 
@@ -151,26 +147,22 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>matrix-project</artifactId>
-			<version>1.7.1</version>
 			<optional>true</optional>
 		</dependency>
 		<!-- Workflow plugin imports are used to test compatibility -->
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-job</artifactId>
-			<version>${workflow.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-cps</artifactId>
-			<version>${workflow.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins.workflow</groupId>
 			<artifactId>workflow-basic-steps</artifactId>
-			<version>${workflow.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<!--
@@ -294,7 +286,6 @@
 
 	<properties>
 		<findbugs.failOnError>false</findbugs.failOnError>
-				<workflow.version>1.6</workflow.version>
                 <jenkins.version>2.319.3</jenkins.version>
 		<java.level>8</java.level>
 		<changelist>999999-SNAPSHOT</changelist>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.jenkins-ci.plugins</groupId>
 		<artifactId>plugin</artifactId>
-		<version>3.2</version>
+		<version>4.40</version>
                 <relativePath />
 	</parent>
 
@@ -45,6 +45,26 @@
 		<tag>${scmTag}</tag>
 	</scm>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.jenkins-ci.main</groupId>
+				<artifactId>jenkins-bom</artifactId>
+				<version>${jenkins.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+
+			<dependency>
+				<groupId>io.jenkins.tools.bom</groupId>
+				<artifactId>bom-2.319.x</artifactId>
+				<version>1409.v7659b_c072f18</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
@@ -56,7 +76,11 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>junit</artifactId>
-			<version>1.11</version>
+			<!--
+				1.25 and earlier are vulnerable
+				https://www.jenkins.io/security/advisory/2018-09-25/
+			-->
+			<version>1.26</version>
 		</dependency>
 
 		<dependency>
@@ -80,13 +104,17 @@
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>
 			<artifactId>mailer</artifactId>
-			<version>1.13</version>
+			<version>1.32.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jenkins-ci.main</groupId>
 			<artifactId>maven-plugin</artifactId>
-			<version>2.6</version>
+			<!--
+				3.3 and earlier are vulnerable
+				https://www.jenkins.io/security/advisory/2019-07-31/
+			-->
+			<version>3.4</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.httpcomponents</groupId>
@@ -145,6 +173,21 @@
 			<version>${workflow.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<!--
+			this is here to resolve a RequireUpperBoundDeps failure
+			between maven-plugin (3.6) and jenkins-test-harness (3.8)
+		 -->
+		 <dependency>
+			<groupId>org.jenkins-ci.main</groupId>
+			<artifactId>jenkins-test-harness</artifactId>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-net</groupId>
+					<artifactId>commons-net</artifactId>
+				</exclusion>
+			</exclusions>
+		 </dependency>
 
 	</dependencies>
 
@@ -252,7 +295,7 @@
 	<properties>
 		<findbugs.failOnError>false</findbugs.failOnError>
 				<workflow.version>1.6</workflow.version>
-                <jenkins.version>2.120</jenkins.version>
+                <jenkins.version>2.319.3</jenkins.version>
 		<java.level>8</java.level>
 		<changelist>999999-SNAPSHOT</changelist>
 	</properties>

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
@@ -326,10 +326,7 @@ public class MultiJobBuild extends Build<MultiJobProject, MultiJobBuild> {
         @CheckForNull
 		public Run<?,?> getBuild() {
             if (buildID != null) {
-                Run<?, ?> build = Run.fromExternalizableId(buildID);
-                if (build instanceof Run) {
-                    return (Run) build;
-                }
+                return Run.fromExternalizableId(buildID);
             } // else null if loaded from historical data prior to JENKINS-49328
 			return null;
 		}

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuildSelector.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuildSelector.java
@@ -1,5 +1,6 @@
 package com.tikal.jenkins.plugins.multijob;
 
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import hudson.matrix.MatrixRun;
@@ -49,7 +50,7 @@ public class MultiJobBuildSelector extends BuildSelector {
                 }
                 UpstreamCause upstreamCause = (UpstreamCause)cause;
                 Job upstreamJob = Jenkins.getInstance().getItemByFullName(upstreamCause.getUpstreamProject(), Job.class);
-                Run upstreamRun = upstreamJob.getBuildByNumber(upstreamCause.getUpstreamBuild());
+                Run upstreamRun = Optional.ofNullable(upstreamJob).map(j -> j.getBuildByNumber(upstreamCause.getUpstreamBuild())).orElse(null);
 
                 if (upstreamRun != null && upstreamRun instanceof MultiJobBuild) {
                     multiJobBuild = (MultiJobBuild)upstreamRun;

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuilder.java
@@ -608,17 +608,12 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                 try {
                     listener.getLogger().println("Scanning failed job console output using parsing rule file " + subTask.phaseConfig.getParsingRulesPath() + ".");
                     final File rulesFile = new File(subTask.phaseConfig.getParsingRulesPath());
-                    FileInputStream fis = new FileInputStream(rulesFile.getAbsoluteFile());
-                    InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
-                    final BufferedReader reader = new BufferedReader(isr);
-                    try {
+                    try (FileInputStream fis = new FileInputStream(rulesFile.getAbsoluteFile());
+                         InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
+                         BufferedReader reader = new BufferedReader(isr)) {
                         String line;
                         while ((line = reader.readLine()) != null) {
                             compiledPatterns.add(Pattern.compile(line));
-                        }
-                    } finally {
-                        if (reader != null) {
-                            reader.close();
                         }
                     }
                 } catch (Exception e) {
@@ -679,10 +674,9 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
             try {
                 final List<Pattern> patterns = getCompiledPattern();
                 final File logFile = build.getLogFile();
-                FileInputStream fis = new FileInputStream(logFile);
-                InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
-                final BufferedReader reader = new BufferedReader(isr);
-                try {
+                try (FileInputStream fis = new FileInputStream(logFile);
+                     InputStreamReader isr = new InputStreamReader(fis, StandardCharsets.UTF_8);
+                     BufferedReader reader = new BufferedReader(isr)) {
                     int numberOfThreads = 10; // Todo : Add this in Configure section
                     if (numberOfThreads < 0) {
                         numberOfThreads = 1;
@@ -708,10 +702,6 @@ public class MultiJobBuilder extends Builder implements DependecyDeclarer {
                         }
                     }
                     executorAnalyser.shutdownNow();
-                } finally {
-                    if (reader != null) {
-                        reader.close();
-                    }
                 }
             } catch (Exception e) {
                 if (e instanceof InterruptedException) {

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobProject.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobProject.java
@@ -101,7 +101,7 @@ public class MultiJobProject extends Project<MultiJobProject, MultiJobBuild>
                 return result;
             }
             List<AbstractProject> downProjs = getDownstreamProjects();
-            PollingResult tmpResult = new PollingResult(PollingResult.Change.NONE);
+            PollingResult tmpResult;
             //return when we get changes to save resources
             //If we don't get changes, return the most significant result
             for (AbstractProject downProj : downProjs) {

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/PhaseJobsConfig.java
@@ -30,6 +30,7 @@ import hudson.tasks.Builder;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -365,7 +366,7 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 		}
 
 		public ParserRuleFile[] getParsingRulesGlobal() {
-			return parsingRulesGlobal;
+			return Arrays.copyOf(parsingRulesGlobal, parsingRulesGlobal.length);
 		}
 
 		@Override
@@ -384,11 +385,11 @@ public class PhaseJobsConfig implements Describable<PhaseJobsConfig> {
 		ParametersAction action = build.getAction(ParametersAction.class);
 		List<ParameterValue> values = new ArrayList<ParameterValue>(action
 				.getParameters().size());
-		if (action != null) {
-			for (ParameterValue value : action.getParameters())
-				// FileParameterValue is currently not reusable, so omit these:
-				if (!(value instanceof FileParameterValue))
-					values.add(value);
+		for (ParameterValue value : action.getParameters()) {
+			// FileParameterValue is currently not reusable, so omit these:
+			if (!(value instanceof FileParameterValue)) {
+				values.add(value);
+			}
 		}
 
 		return values;

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/PredefinedBuildParameters.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/PredefinedBuildParameters.java
@@ -39,7 +39,9 @@ public class PredefinedBuildParameters extends AbstractBuildParameters {
 //
 //        }
         Properties pProp = new Properties();
-        pProp.load(new StringInputStream(jobProperties));
+        try (StringInputStream is = new StringInputStream(jobProperties)) {
+            pProp.load(is);
+        }
         LinkedHashMap<String,ParameterValue> params = new LinkedHashMap<String,ParameterValue>();
 
 //        if (parameters !=null){

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobListViewColumn.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobListViewColumn.java
@@ -5,6 +5,7 @@ import hudson.model.Descriptor;
 import hudson.model.Descriptor.FormException;
 import hudson.views.BuildButtonColumn;
 import hudson.views.ListViewColumn;
+import net.sf.json.JSONObject;
 import org.jenkins.plugins.builton.BuiltOnColumn;
 
 import java.util.ArrayList;
@@ -24,7 +25,7 @@ abstract public class MultiJobListViewColumn extends ListViewColumn {
             Descriptor<ListViewColumn> des = all.find(d);
             if (des != null) {
                 try {
-                    r.add(des.newInstance(null, null));
+                    r.add(des.newInstance(null, new JSONObject()));
                 } catch (FormException e) {
                     LOGGER.log(Level.WARNING, "Failed to instantiate " + des.clazz, e);
                 }

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobView.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobView.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -38,6 +40,7 @@ import com.tikal.jenkins.plugins.multijob.MultiJobProject;
 import com.tikal.jenkins.plugins.multijob.PhaseJobsConfig;
 
 public class MultiJobView extends ListView {
+    private final static Logger LOG = Logger.getLogger(MultiJobView.class.getName());
 
     @DataBoundConstructor
     public MultiJobView(String name) {
@@ -427,7 +430,7 @@ public class MultiJobView extends ListView {
             getColumns().replaceBy(MultiJobListViewColumn
                     .createDefaultInitialColumnList());
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.log(Level.WARNING, "Failed to initialize columns", e);
         }
     }
 

--- a/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobView.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/views/MultiJobView.java
@@ -16,8 +16,10 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -149,7 +151,10 @@ public class MultiJobView extends ListView {
                 nestLevel,
                 build)
         );
-        List<Builder> builders = build.getProject().getBuilders();
+        List<Builder> builders = Optional.ofNullable(build)
+                .map(AbstractBuild::getProject)
+                .map(Project::getBuilders)
+                .orElseGet(Collections::emptyList);
         for (Builder builder : builders) {
             int phaseNestLevel = nestLevel + 1;
             if (builder instanceof MultiJobBuilder) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Hi, I see this plugin has been deprecated recently. We have quite a few jobs that rely on it, so I was curious what it would take to bring it up to the latest plugin version vs converting to pipelines. It ended up being straightforward, so I thought I'd submit this PR to see if there was interest in merging.

The bulk of the work was in getting compliant with the spotbugs rules that come enabled by default in parent version 4.40. These are mainly around preventing NPEs, exception handling, and stream closing.
I chose to use Jenkins 2.319.3 as a baseline based on [the guide](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/).
I bumped several plugins that were not included in the plugins-bom based on [security advisories](https://www.jenkins.io/security/advisories/).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Closes #227 
Closes #237 
Closes #238 
Closes #241 
Closes #242 
Closes #247 
Closes #246 