### PR TITLE
fix: Display console icon in job table correctly

### DIFF
--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/views/ConsoleColumn/column.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/views/ConsoleColumn/column.jelly
@@ -7,7 +7,7 @@
 		<j:choose>
 			<j:when test="${lBuild!=null}">
 				<a href="${job.absoluteUrl}${job.getBuildNumber()}/console">
-					<l:icon class="icon-terminal icon-${subIconSizeClass}" title="${%Console output}"
+					<l:icon class="icon-terminal ${subIconSizeClass}" title="${%Console output}"
 						alt="${%Console output}" border="0" />
 				</a>
 			</j:when>


### PR DESCRIPTION
Fixes: https://github.com/jenkinsci/tikal-multijob-plugin/issues/282

The solution is the same as the one used in: https://github.com/jenkinsci/jenkins/blob/53d91017ca491732635e0c1ed67c59794eb0d060/core/src/main/resources/lib/hudson/ballColorTd.jelly#L61. The `icon-` prefix is extraneous; this PR removes it.