### PR TITLE
Prevent infinite loop in multijob view, fixes #255

### DIFF
--- a/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
+++ b/src/main/java/com/tikal/jenkins/plugins/multijob/MultiJobBuild.java
@@ -322,7 +322,12 @@ public class MultiJobBuild extends Build<MultiJobProject, MultiJobBuild> {
                     + ", buildNumber=" + buildNumber + "]";
         }
 
-		@Exported
+        @Exported
+        public String getBuildID() {
+            return buildID;
+        }
+
+        @Exported
         @CheckForNull
 		public Run<?,?> getBuild() {
             if (buildID != null) {

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuild/main.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuild/main.jelly
@@ -43,6 +43,10 @@
 			<j:set var="lastPhase" value=""/>
 			<j:set var="builders" value="${it.getBuilders()}"/>
 			<j:set var="indent" value="1"/>
+			<j:new var="parents" className="java.util.ArrayDeque"/>
+			<j:invoke on="${parents}" method="push">
+				<j:arg value="${it.getExternalizableId()}"/>
+			</j:invoke>
 
 			<st:include page="table.jelly" />
 

--- a/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuild/table.jelly
+++ b/src/main/resources/com/tikal/jenkins/plugins/multijob/MultiJobBuild/table.jelly
@@ -68,7 +68,7 @@
 			</tr>
 		</j:choose>
 		<j:choose>
-			<j:when test="${builder.isMultiJobBuild()}">
+			<j:when test="${builder.isMultiJobBuild() and not parents.contains(builder.buildID)}">
 				<j:set var="oldLastPhase" value="${lastPhase}"/>
 				<j:set var="oldBuilders" value="${builders}"/>
 				<j:set var="oldIndent" value="${indent}"/>
@@ -76,9 +76,13 @@
 				<j:set var="lastPhase" value=""/>
 				<j:set var="builders" value="${builder.build.getSubBuilds()}"/>
 				<j:set var="indent" value="${indent + 2}"/>
+				<j:invoke on="${parents}" method="push">
+					<j:arg value="${builder.buildID}"/>
+				</j:invoke>
 
 				<st:include page="table.jelly" />
 
+				<j:invoke on="${parents}" method="pop"/>
 				<j:set var="lastPhase" value="${oldLastPhase}"/>
 				<j:set var="builders" value="${oldLastBuilders}"/>
 				<j:set var="indent" value="${oldIndent}"/>


### PR DESCRIPTION
`table.jelly` view includes itself recursively to expand the downstream multijobs triggered from the current multijob. When the multijob has reference loops it goes into an infinite recursion. To prevent that I added upstream builds tracking.

### Testing done

Tested manually

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue